### PR TITLE
Accept settings file path as an argument

### DIFF
--- a/DuplicateTagFinder.fsx
+++ b/DuplicateTagFinder.fsx
@@ -95,6 +95,7 @@ module Settings =
 
     type SettingsProvider = JsonProvider<settingsSample>
     type SettingsRoot = SettingsProvider.Root
+    type Exclusion = SettingsProvider.Exclusion
 
     type ExclusionPair =
         { Artist: string option
@@ -106,15 +107,16 @@ module Settings =
           TitleReplacements: string array }
 
     let toSettings (settings: SettingsRoot) : SettingsType =
-        { Exclusions =
-              settings.Exclusions
-              |> Array.map (fun e ->
-                {
-                    Artist = Some (extractText e.Artist)
-                    Title = Some (extractText e.Title)
-                })
-          ArtistReplacements = settings.ArtistReplacements |> Array.map extractText
-          TitleReplacements = settings.TitleReplacements |> Array.map extractText
+        let toExclusionPair (e: Exclusion) =
+            {
+                Artist = Some (extractText e.Artist)
+                Title = Some (extractText e.Title)
+            }
+
+        {
+            Exclusions = settings.Exclusions |> Array.map toExclusionPair
+            ArtistReplacements = settings.ArtistReplacements |> Array.map extractText
+            TitleReplacements = settings.TitleReplacements |> Array.map extractText
         }
 
     let load (json: string) : Result<SettingsType, Error> =

--- a/DuplicateTagFinder.fsx
+++ b/DuplicateTagFinder.fsx
@@ -98,7 +98,7 @@ module Settings =
           TitleReplacements = settings.TitleReplacements |> Array.map extractText
         }
 
-    let load (json: string) : Result<SettingsType,Error> =
+    let load (json: string) : Result<SettingsType, Error> =
         try
             json
             |> SettingsProvider.Load
@@ -177,13 +177,15 @@ module Tags =
 
             let isExcluded rule =
                 match rule.Artist, rule.Title with
-                | Some a, Some t ->
-                    (tags.AlbumArtists |> contains a || tags.Artists |> contains a) &&
-                    tags.Title.StartsWith(t, StringComparison.InvariantCultureIgnoreCase)
-                | Some a, None ->
-                    tags.AlbumArtists |> contains a || tags.Artists |> contains a
-                | None, Some t ->
-                    tags.Title.StartsWith(t, StringComparison.InvariantCultureIgnoreCase)
+                | Some excludedArtist, Some excludedTitle ->
+                    (contains excludedArtist tags.AlbumArtists ||
+                    contains excludedArtist tags.Artists) &&
+                    tags.Title.StartsWith(excludedTitle, StringComparison.InvariantCultureIgnoreCase)
+                | Some excludedArtist, None ->
+                    contains excludedArtist tags.AlbumArtists ||
+                    contains excludedArtist tags.Artists
+                | None, Some excludedTitle ->
+                    tags.Title.StartsWith(excludedTitle, StringComparison.InvariantCultureIgnoreCase)
                 | _ -> false
 
             settings.Exclusions


### PR DESCRIPTION
Child PR of #1:
- Instead of hardcoding the settings filename and limiting its location to the application directory, allow users to pass it in as an argument
- Miscellaneous minor tweaks (that really should have gone in the parent PR 😅)