### PR TITLE
Workaround: JSON type providers seemingly don't import whitespace-only values

### DIFF
--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -23,7 +23,7 @@ let savePlaylist (settings: SettingsRoot) (tags: FileTags array array) : Result<
         let xy = Array.append x y
         String.Join("; ", xy)
 
-    let update (m: TagLibrary.FileTags) : unit =
+    let update (m: FileTags) : unit =
         let seconds = m.Duration.TotalSeconds
         let artist = combine m.AlbumArtists m.Artists
         let artistTitle = $"{artist} - {m.Title}"

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -1,22 +1,19 @@
 module IO
 
-open System
-open System.Text
 open Errors
 open Settings
-open System.IO
+open TagLibrary
 open AudioTagTools.Shared.IO
+open System
+open System.Text
+open System.IO
 open FsToolkit.ErrorHandling
 
 let readFile (fileInfo: FileInfo) : Result<string, Error> =
     readFile fileInfo
     |> Result.mapError ReadFileError
 
-let savePlaylist
-    (settings: SettingsRoot)
-    (tags: Map<string, TagLibrary.FilteredTagCollection>)
-    : Result<string, Error>
-    =
+let savePlaylist (settings: SettingsRoot) (tags: FileTags array array) : Result<string, Error> =
     let mutable contents = StringBuilder("#EXTM3U\n")
     let now = DateTime.Now.ToString("yyyyMMdd_HHmmss")
     let filename = $"Duplicates by AudioTagTools - {now}.m3u"
@@ -43,7 +40,7 @@ let savePlaylist
 
         contents.AppendLine updatedPath |> ignore
 
-    tags.Values
+    tags
     |> Seq.collect id
     |> Seq.iter update
 

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -30,27 +30,38 @@ let filter (settings: SettingsRoot) (allTags: FileTagCollection) : FileTags arra
     allTags
     |> Array.filter (not << excludeFile settings)
 
-let findDuplicates
-    (settings: SettingsRoot)
-    (tags: FilteredTagCollection)
-    : Map<string, FilteredTagCollection>
-    =
+let private hasAnyArtist (track: FileTags) =
+    track.Artists.Length > 0 || track.AlbumArtists.Length > 0
+
+let private hasTitle (track: FileTags) =
+    not <| String.IsNullOrWhiteSpace track.Title
+
+let private hasArtistOrTitle track =
+    hasAnyArtist track && hasTitle track
+
+let private groupName (settings: SettingsRoot) (track: FileTags) =
+    // It appears type providers do not import spaces. Spaces should
+    // always be removed for duplicate checks, so I add them here.
+    let removeSubstrings arr =
+        removeSubstrings (Array.append [| " "; "　" |] arr)
+
+    let artists =
+        match track with
+        | t when t.AlbumArtists.Length > 0 -> t.AlbumArtists
+        | t -> t.Artists
+        |> String.Concat
+        |> removeSubstrings settings.ArtistReplacements
+    let title =
+        track.Title
+        |> removeSubstrings settings.TitleReplacements
+    $"{artists}{title}"
+
+let findDuplicates (settings: SettingsRoot) (tags: FilteredTagCollection) : FileTags array array =
     tags
-    |> Array.filter (fun track ->
-        let hasArtists = track.Artists.Length > 0
-        let hasTitle = not <| String.IsNullOrWhiteSpace track.Title
-        hasArtists && hasTitle)
-    |> Array.groupBy (fun track ->
-        let artists =
-            track.Artists
-            |> String.Concat
-            |> removeSubstrings settings.ArtistReplacements
-        let title =
-            track.Title
-            |> removeSubstrings settings.TitleReplacements
-        $"{artists}{title}")
+    |> Array.filter hasArtistOrTitle
+    |> Array.groupBy (groupName settings)
     |> Array.filter (fun (_, groupedTracks) -> groupedTracks.Length > 1)
-    |> Map.ofArray
+    |> Array.map snd
 
 let printTotalCount (tags: FileTagCollection) =
     printfn $"Total file count:    %s{formatNumber tags.Length}"
@@ -58,13 +69,11 @@ let printTotalCount (tags: FileTagCollection) =
 let printFilteredCount (tags: FilteredTagCollection) =
     printfn $"Filtered file count: %s{formatNumber tags.Length}"
 
-let printResults (groupedTracks: Map<string, FilteredTagCollection>) =
-    if groupedTracks.IsEmpty
+let printResults (groupedTracks: FileTags array array) =
+    if Array.isEmpty groupedTracks
     then printfn "No duplicates found."
     else
         groupedTracks
-        |> Map.values
-        |> Array.ofSeq
         |> Array.iteri (fun i groupTracks ->
             // Print the artist from this group's first file's artists.
             groupTracks

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -40,8 +40,8 @@ let private hasArtistOrTitle track =
     hasAnyArtist track && hasTitle track
 
 let private groupName (settings: SettingsRoot) (track: FileTags) =
-    // It appears type providers do not import spaces. Spaces should
-    // always be removed for duplicate checks, so I add them here.
+    // It appears JSON type providers do not import whitespace-only values. Whitespace should
+    // always be ignored to increase the accuracy of duplicate checks, so they are added here.
     let removeSubstrings arr =
         removeSubstrings (Array.append [| " "; "　" |] arr)
 
@@ -51,9 +51,11 @@ let private groupName (settings: SettingsRoot) (track: FileTags) =
         | t -> t.Artists
         |> String.Concat
         |> removeSubstrings settings.ArtistReplacements
+
     let title =
         track.Title
         |> removeSubstrings settings.TitleReplacements
+
     $"{artists}{title}"
 
 let findDuplicates (settings: SettingsRoot) (tags: FilteredTagCollection) : FileTags array array =


### PR DESCRIPTION
I learned that F# JSON type providers will apparently not import whitespace-only values. This is problematic because my duplicate-finding settings include whitespace entries.

I haven't found a way around this yet, so am baking the spaces into the code because spaces should always be ignored to increase the accuracy of the search.