### PR TITLE
Parse file tags safely

### DIFF
--- a/src/AudioTagTools.Cacher/Errors.fs
+++ b/src/AudioTagTools.Cacher/Errors.fs
@@ -6,7 +6,8 @@ type Error =
     | ReadFileError of string
     | WriteFileError of string
     | GeneralIoError of string
-    | ParseError of string
+    | LibraryTagParseError of string
+    | FileTagParseError of string
     | JsonSerializationError of string
 
 let message = function
@@ -15,5 +16,6 @@ let message = function
     | ReadFileError msg -> $"Read failure: {msg}"
     | WriteFileError msg -> $"Write failure: {msg}"
     | GeneralIoError msg -> $"I/O failure: {msg}"
-    | ParseError msg -> $"Parse error: {msg}"
+    | LibraryTagParseError msg -> $"Library tag arse error: {msg}"
+    | FileTagParseError msg -> $"File tag parse error: {msg}"
     | JsonSerializationError msg -> $"JSON serialization error: {msg}"

--- a/src/AudioTagTools.Cacher/Errors.fs
+++ b/src/AudioTagTools.Cacher/Errors.fs
@@ -16,6 +16,6 @@ let message = function
     | ReadFileError msg -> $"Read failure: {msg}"
     | WriteFileError msg -> $"Write failure: {msg}"
     | GeneralIoError msg -> $"I/O failure: {msg}"
-    | LibraryTagParseError msg -> $"Library tag arse error: {msg}"
+    | LibraryTagParseError msg -> $"Library tag parse error: {msg}"
     | FileTagParseError msg -> $"File tag parse error: {msg}"
     | JsonSerializationError msg -> $"JSON serialization error: {msg}"

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -26,14 +26,14 @@ let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
 
 let parseJsonToTags (json: string) : Result<LibraryTags array, Error> =
     parseJsonToTags json
-    |> Result.mapError ParseError
+    |> Result.mapError LibraryTagParseError
 
 let parseFileTags (filePath: string) : Result<FileTags option, Error> =
     try
         FileTags.Create filePath
         |> Option.ofObj
         |> Ok
-    with e -> Error (ParseError e.Message)
+    with e -> Error (FileTagParseError e.Message)
 
 let writeFile (filePath: string) (content: string) : Result<unit, Error> =
     try Ok (File.WriteAllText(filePath, content))

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -3,6 +3,7 @@ module IO
 open System.IO
 open Errors
 open Utilities
+open TagLibrary
 
 type TaggedFile = TagLib.File
 
@@ -22,6 +23,10 @@ let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
         |> Ok
     with
     | e -> Error (GeneralIoError e.Message)
+
+let parseJsonToTags (json: string) : Result<LibraryTags array, Error> =
+    parseJsonToTags json
+    |> Result.mapError ParseError
 
 let parseFileTags (filePath: string) : Result<TaggedFile, Error> =
     try Ok (TaggedFile.Create filePath)

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -28,8 +28,11 @@ let parseJsonToTags (json: string) : Result<LibraryTags array, Error> =
     parseJsonToTags json
     |> Result.mapError ParseError
 
-let parseFileTags (filePath: string) : Result<FileTags, Error> =
-    try Ok (FileTags.Create filePath)
+let parseFileTags (filePath: string) : Result<FileTags option, Error> =
+    try
+        FileTags.Create filePath
+        |> Option.ofObj
+        |> Ok
     with e -> Error (ParseError e.Message)
 
 let writeFile (filePath: string) (content: string) : Result<unit, Error> =

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -5,7 +5,7 @@ open Errors
 open Utilities
 open TagLibrary
 
-type TaggedFile = TagLib.File
+type FileTags = TagLib.File
 
 let readfile filePath : Result<string, Error> =
     match readAllText filePath with
@@ -28,8 +28,8 @@ let parseJsonToTags (json: string) : Result<LibraryTags array, Error> =
     parseJsonToTags json
     |> Result.mapError ParseError
 
-let parseFileTags (filePath: string) : Result<TaggedFile, Error> =
-    try Ok (TaggedFile.Create filePath)
+let parseFileTags (filePath: string) : Result<FileTags, Error> =
+    try Ok (FileTags.Create filePath)
     with e -> Error (ParseError e.Message)
 
 let writeFile (filePath: string) (content: string) : Result<unit, Error> =

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -23,12 +23,10 @@ let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
     with
     | e -> Error (GeneralIoError e.Message)
 
-let readFileTags (filePath: string) : TaggedFile =
-    TaggedFile.Create filePath // TODO: Enclose in try/with.
+let readFileTags (filePath: string) : Result<TaggedFile, Error> =
+    try Ok (TaggedFile.Create filePath)
+    with e -> Error (ParseError e.Message)
 
 let writeFile (filePath: string) (content: string) : Result<unit, Error> =
-    try
-        File.WriteAllText(filePath, content)
-        |> Ok
-    with
-    | e -> Error (WriteFileError e.Message)
+    try Ok (File.WriteAllText(filePath, content))
+    with e -> Error (WriteFileError e.Message)

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -23,7 +23,7 @@ let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
     with
     | e -> Error (GeneralIoError e.Message)
 
-let readFileTags (filePath: string) : Result<TaggedFile, Error> =
+let parseFileTags (filePath: string) : Result<TaggedFile, Error> =
     try Ok (TaggedFile.Create filePath)
     with e -> Error (ParseError e.Message)
 

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -9,8 +9,6 @@ open FsToolkit.ErrorHandling
 open AudioTagTools.Shared.IO
 
 let private run (args: string array) : Result<unit, Error> =
-    printfn "Starting..."
-
     result {
         let! mediaDir, tagLibraryFile = validate args
         let! fileInfos = getFileInfos mediaDir

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -9,6 +9,8 @@ open FsToolkit.ErrorHandling
 open AudioTagTools.Shared.IO
 
 let private run (args: string array) : Result<unit, Error> =
+    printfn "Starting..."
+
     result {
         let! mediaDir, tagLibraryFile = validate args
         let! fileInfos = getFileInfos mediaDir

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -70,7 +70,7 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
-        let tagsFromFile (fileInfo: FileInfo) (fileTags: TaggedFile) =
+        let tagsFromFile (fileInfo: FileInfo) (fileTags: FileTags) =
             {
                 FileNameOnly = fileInfo.Name
                 DirectoryName = fileInfo.DirectoryName

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -7,21 +7,8 @@ open Errors
 open Operators
 open Utilities
 open FsToolkit.ErrorHandling
+open TagLibrary
 
-type LibraryTags =
-    {
-        FileNameOnly: string
-        DirectoryName: string
-        Artists: string array
-        AlbumArtists: string array
-        Album: string
-        TrackNo: uint
-        Title: string
-        Year: uint
-        Genres: string array
-        Duration: TimeSpan
-        LastWriteTime: DateTimeOffset
-    }
 
 type TagMap = Map<string, LibraryTags>
 
@@ -35,9 +22,6 @@ type CategorizedTagsToCache =
       Tags: LibraryTags }
 
 let createTagLibraryMap (libraryFile: FileInfo) : Result<TagMap, Error> =
-    let parseTagLibrary (json: string) : Result<LibraryTags array, Error> =
-        try Ok (JsonSerializer.Deserialize<LibraryTags array>(json))
-        with e -> Error (ParseError e.Message)
 
     let audioFilePath (fileTags: LibraryTags) : string =
         Path.Combine [| fileTags.DirectoryName; fileTags.FileNameOnly |]
@@ -46,7 +30,7 @@ let createTagLibraryMap (libraryFile: FileInfo) : Result<TagMap, Error> =
     then
         libraryFile.FullName
         |> readfile
-        >>= parseTagLibrary
+        >>= IO.parseJsonToTags
         <!> Array.map (fun tags -> audioFilePath tags, tags)
         <!> Map.ofArray
     else

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -74,20 +74,17 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
             {
                 FileNameOnly = fileInfo.Name
                 DirectoryName = fileInfo.DirectoryName
-                Artists = if fileTags.Tag.Performers = null
-                          then [| String.Empty |]
-                          else fileTags.Tag.Performers
-                               |> Array.map (fun p -> p.Normalize())
-                AlbumArtists = if fileTags.Tag.AlbumArtists = null
-                               then [| String.Empty |]
-                               else fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
-                Album = if fileTags.Tag.Album = null
-                        then String.Empty
-                        else fileTags.Tag.Album.Normalize()
+                Artists = fileTags.Tag.Performers |> Array.map _.Normalize()
+                AlbumArtists = fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
+                Album = fileTags.Tag.Album
+                        |> Option.ofObj
+                        |> Option.map _.Normalize()
+                        |> Option.defaultValue String.Empty
                 TrackNo = fileTags.Tag.Track
-                Title = if fileTags.Tag.Title = null
-                        then String.Empty
-                        else fileTags.Tag.Title.Normalize()
+                Title = fileTags.Tag.Title
+                        |> Option.ofObj
+                        |> Option.map _.Normalize()
+                        |> Option.defaultValue String.Empty
                 Year = fileTags.Tag.Year
                 Genres = fileTags.Tag.Genres
                 Duration = fileTags.Properties.Duration

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -94,14 +94,9 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
-        let fileTags = parseFileTags fileInfo.FullName
-
-        match fileTags with
-        | Error _ -> blankTags
-        | Ok fileTags ->
-            if fileTags.Tag = null
-            then blankTags
-            else tagsFromFile fileInfo fileTags
+        match parseFileTags fileInfo.FullName with
+        | Ok (Some tags) -> tagsFromFile fileInfo tags
+        | _ -> blankTags
 
     let prepareTagsToCache (tagLibraryMap: TagMap) (audioFile: FileInfo) : CategorizedTagsToCache =
         if Map.containsKey audioFile.FullName tagLibraryMap

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -85,7 +85,9 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                         then String.Empty
                         else fileTags.Tag.Album.Normalize()
                 TrackNo = fileTags.Tag.Track
-                Title = fileTags.Tag.Title
+                Title = if fileTags.Tag.Title = null
+                        then String.Empty
+                        else fileTags.Tag.Title.Normalize()
                 Year = fileTags.Tag.Year
                 Genres = fileTags.Tag.Genres
                 Duration = fileTags.Properties.Duration

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -24,9 +24,9 @@ type TagsToWrite =
     }
 
 type ComparisonResult =
-    | Unchanged
-    | OutOfDate // The file tags are newer than the library's.
-    | NotPresent // Tags for the specified file don't exist in the tag library.
+    | Unchanged // File tags match the library tags.
+    | OutOfDate // File tags are newer than library tags.
+    | NotPresent // File tags do not exist in tag library.
 
 [<Literal>]
 let private tagSample = """

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -49,7 +49,7 @@ let private tagSample = """
 type TagLibraryProvider = JsonProvider<tagSample>
 type Tags = TagLibraryProvider.Root
 type TagMap = Map<string, Tags>
-type CategorizedTagsToWrite =
+type CategorizedTagsToSave =
     { Category: ComparisonResult
       Tags: TagsToWrite }
 
@@ -76,7 +76,7 @@ let createTagLibraryMap (tagLibraryFile: FileInfo) : Result<TagMap, Error> =
         Ok Map.empty
 
 let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
-    : CategorizedTagsToWrite seq
+    : CategorizedTagsToSave seq
     =
     let copyCachedTags (libraryTags: Tags) =
         {
@@ -133,7 +133,7 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
             then blankTags
             else tagsFromFile fileInfo fileTags
 
-    let prepareTags (tagLibraryMap: TagMap) (audioFile: FileInfo) : CategorizedTagsToWrite =
+    let prepareTags (tagLibraryMap: TagMap) (audioFile: FileInfo) : CategorizedTagsToSave =
         if Map.containsKey audioFile.FullName tagLibraryMap
         then
             let libraryTags = Map.find audioFile.FullName tagLibraryMap
@@ -145,7 +145,7 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
     fileInfos
     |> Seq.map (prepareTags tagLibraryMap)
 
-let private reportResults (results: CategorizedTagsToWrite seq) : CategorizedTagsToWrite seq =
+let private reportResults (results: CategorizedTagsToSave seq) : CategorizedTagsToSave seq =
     let initialCounts = {| NotPresent = 0; OutOfDate = 0; Unchanged = 0 |}
 
     let totals =

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -121,7 +121,7 @@ let compareAndUpdateTagData (tagLibraryMap: TagLibraryMap) (fileInfos: FileInfo 
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
-        let fileTags = readFileTags fileInfo.FullName
+        let fileTags = parseFileTags fileInfo.FullName
 
         match fileTags with
         | Error _ -> blankTags

--- a/src/AudioTagTools.Console/Program.fs
+++ b/src/AudioTagTools.Console/Program.fs
@@ -26,6 +26,8 @@ let main args : int =
         let command = args[0]
         let flags = args[1..]
 
+        printfn "Starting..."
+
         match Map.tryFind command commandMap with
         | Some requestedOperation ->
             match requestedOperation flags with

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -14,12 +14,12 @@ let readFile (fileInfo: FileInfo) : Result<string, Error> =
     |> readFile
     |> Result.mapError ReadFileError
 
-let savePlaylist (settings: SettingsRoot) (tags: FileTags array array) : Result<unit, Error> =
+let savePlaylist (settings: SettingsRoot) (tags: LibraryTags array array) : Result<unit, Error> =
     let now = DateTime.Now.ToString("yyyyMMdd_HHmmss")
     let filename = $"Duplicates by AudioTagTools - {now}.m3u"
     let fullPath = Path.Combine(settings.Playlist.SaveDirectory, filename)
 
-    let appendFileEntry (builder: StringBuilder) (m: FileTags) : StringBuilder =
+    let appendFileEntry (builder: StringBuilder) (m: LibraryTags) : StringBuilder =
         let seconds = m.Duration.TotalSeconds
         let artist = Array.append m.AlbumArtists m.Artists |> String.concat "; "
         let artistWithTitle = $"{artist} - {m.Title}"

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -14,7 +14,7 @@ let readFile (fileInfo: FileInfo) : Result<string, Error> =
     |> readFile
     |> Result.mapError ReadFileError
 
-let savePlaylist (settings: SettingsRoot) (tags: LibraryTags array array) : Result<unit, Error> =
+let savePlaylist (settings: SettingsRoot) (tags: LibraryTags array array option) : Result<unit, Error> =
     let now = DateTime.Now.ToString("yyyyMMdd_HHmmss")
     let filename = $"Duplicates by AudioTagTools - {now}.m3u"
     let fullPath = Path.Combine(settings.Playlist.SaveDirectory, filename)
@@ -36,10 +36,13 @@ let savePlaylist (settings: SettingsRoot) (tags: LibraryTags array array) : Resu
         builder.AppendLine updatedPath |> ignore
         builder
 
-    tags
-    |> Seq.collect id
-    |> Seq.fold appendFileEntry (StringBuilder "#EXTM3U\n")
-    |> _.ToString()
-    |> writeTextToFile fullPath
-    |> Result.tee (fun _ -> printfn $"Created playlist file \"{fullPath}\".")
-    |> Result.mapError WriteFileError
+    match tags with
+    | None -> Ok ()
+    | Some tags ->
+        tags
+        |> Seq.collect id
+        |> Seq.fold appendFileEntry (StringBuilder "#EXTM3U\n")
+        |> _.ToString()
+        |> writeTextToFile fullPath
+        |> Result.tee (fun _ -> printfn $"Created playlist file \"{fullPath}\".")
+        |> Result.mapError WriteFileError

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -1,6 +1,5 @@
 ﻿module AudioTagTools.DuplicateFinder
 
-open System
 open Operators
 open Errors
 open ArgValidation

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -9,8 +9,6 @@ open Settings
 open FsToolkit.ErrorHandling
 
 let private run (args: string array) : Result<unit, Error> =
-    printfn "Starting..."
-
     result {
         let! settingsFile, tagLibraryFile = validate args
 

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -9,6 +9,8 @@ open Settings
 open FsToolkit.ErrorHandling
 
 let private run (args: string array) : Result<unit, Error> =
+    printfn "Starting..."
+
     result {
         let! settingsFile, tagLibraryFile = validate args
 

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -72,13 +72,14 @@ let private groupName (settings: SettingsRoot) (track: LibraryTags) =
         .Normalize(NormalizationForm.FormC)
         .ToLowerInvariant()
 
-let findDuplicates (settings: SettingsRoot) (tags: LibraryTags array) : LibraryTags array array =
+let findDuplicates (settings: SettingsRoot) (tags: LibraryTags array) : LibraryTags array array option =
     tags
     |> Array.filter hasArtistOrTitle
     |> Array.groupBy (groupName settings)
     |> Array.sortBy fst
     |> Array.map snd
     |> Array.filter (fun groupedTracks -> groupedTracks.Length > 1)
+    |> function [||] -> None | tagData -> Some tagData
 
 let printTotalCount (tags: LibraryTags array) =
     printfn $"Total file count:    %s{formatNumber tags.Length}"
@@ -86,7 +87,7 @@ let printTotalCount (tags: LibraryTags array) =
 let printFilteredCount (tags: LibraryTags array) =
     printfn $"Filtered file count: %s{formatNumber tags.Length}"
 
-let printResults (groupedTracks: LibraryTags array array) =
+let printResults (groupedTracks: LibraryTags array array option) =
     let print index (groupTracks: LibraryTags array) =
         // Print the joined artists from this group's first file.
         groupTracks
@@ -103,6 +104,6 @@ let printResults (groupedTracks: LibraryTags array array) =
         groupTracks
         |> Array.iter (fun x -> printfn $"""    • {artistText x}{x.Title}""")
 
-    if Array.isEmpty groupedTracks
-    then printfn "No duplicates found."
-    else groupedTracks |> Array.iteri print
+    match groupedTracks with
+    | None -> printfn "No duplicates found."
+    | Some gt -> gt |> Array.iteri print

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -88,7 +88,7 @@ let printFilteredCount (tags: LibraryTags array) =
     printfn $"Filtered file count: %s{formatNumber tags.Length}"
 
 let printResults (groupedTracks: LibraryTags array array option) =
-    let print index (groupTracks: LibraryTags array) =
+    let printGroup index (groupTracks: LibraryTags array) =
         // Print the joined artists from this group's first file.
         groupTracks
         |> Array.head
@@ -106,4 +106,4 @@ let printResults (groupedTracks: LibraryTags array array option) =
 
     match groupedTracks with
     | None -> printfn "No duplicates found."
-    | Some gt -> gt |> Array.iteri print
+    | Some gt -> gt |> Array.iteri printGroup

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -9,20 +9,20 @@ open System
 open System.Text
 
 let parseToTags json =
-    parseToTags json
+    parseJsonToTags json
     |> Result.mapError TagParseError
 
-let filter (settings: SettingsRoot) (allTags: FileTagCollection) : FileTags array =
-    let excludeFile (settings: SettingsRoot) (fileTags: FileTags) : bool =
+let filter (settings: SettingsRoot) (allTags: LibraryTags array) : LibraryTags array =
+    let excludeFile (settings: SettingsRoot) (tags: LibraryTags) : bool =
         let isExcluded (exclusion: SettingsProvider.Exclusion) : bool =
             match exclusion.Artist, exclusion.Title with
             | Some a, Some t ->
-                anyContains [fileTags.AlbumArtists; fileTags.Artists] a &&
-                fileTags.Title.StartsWith(t, StringComparison.InvariantCultureIgnoreCase)
+                anyContains [tags.AlbumArtists; tags.Artists] a &&
+                tags.Title.StartsWith(t, StringComparison.InvariantCultureIgnoreCase)
             | Some a, None ->
-                anyContains [fileTags.AlbumArtists; fileTags.Artists] a
+                anyContains [tags.AlbumArtists; tags.Artists] a
             | None, Some t ->
-                fileTags.Title.StartsWith(t, StringComparison.InvariantCultureIgnoreCase)
+                tags.Title.StartsWith(t, StringComparison.InvariantCultureIgnoreCase)
             | _ -> false
 
         settings.Exclusions
@@ -32,15 +32,15 @@ let filter (settings: SettingsRoot) (allTags: FileTagCollection) : FileTags arra
     |> Array.filter (not << excludeFile settings)
 
 let private hasArtistOrTitle track =
-    let hasAnyArtist (track: FileTags) =
+    let hasAnyArtist (track: LibraryTags) =
         track.Artists.Length > 0 || track.AlbumArtists.Length > 0
 
-    let hasTitle (track: FileTags) =
+    let hasTitle (track: LibraryTags) =
         not <| String.IsNullOrWhiteSpace track.Title
 
     hasAnyArtist track && hasTitle track
 
-let private mainArtists (separator: string) (track: FileTags) =
+let private mainArtists (separator: string) (track: LibraryTags) =
     match track with
     | t when t.AlbumArtists.Length > 0
              && t.AlbumArtists[0] <> "Various"
@@ -51,7 +51,7 @@ let private mainArtists (separator: string) (track: FileTags) =
         t.Artists
     |> String.concat separator
 
-let private groupName (settings: SettingsRoot) (track: FileTags) =
+let private groupName (settings: SettingsRoot) (track: LibraryTags) =
     // It appears JSON type providers do not import whitespace-only values. Whitespace should
     // always be ignored to increase the accuracy of duplicate checks, so they are added here.
     let removeSubstrings arr =
@@ -72,7 +72,7 @@ let private groupName (settings: SettingsRoot) (track: FileTags) =
         .Normalize(NormalizationForm.FormC)
         .ToLowerInvariant()
 
-let findDuplicates (settings: SettingsRoot) (tags: FilteredTagCollection) : FileTags array array =
+let findDuplicates (settings: SettingsRoot) (tags: LibraryTags array) : LibraryTags array array =
     tags
     |> Array.filter hasArtistOrTitle
     |> Array.groupBy (groupName settings)
@@ -80,21 +80,21 @@ let findDuplicates (settings: SettingsRoot) (tags: FilteredTagCollection) : File
     |> Array.map snd
     |> Array.filter (fun groupedTracks -> groupedTracks.Length > 1)
 
-let printTotalCount (tags: FileTagCollection) =
+let printTotalCount (tags: LibraryTags array) =
     printfn $"Total file count:    %s{formatNumber tags.Length}"
 
-let printFilteredCount (tags: FilteredTagCollection) =
+let printFilteredCount (tags: LibraryTags array) =
     printfn $"Filtered file count: %s{formatNumber tags.Length}"
 
-let printResults (groupedTracks: FileTags array array) =
-    let print index (groupTracks: FileTags array) =
+let printResults (groupedTracks: LibraryTags array array) =
+    let print index (groupTracks: LibraryTags array) =
         // Print the joined artists from this group's first file.
         groupTracks
         |> Array.head
         |> mainArtists ", "
         |> printfn "%d. %s" (index + 1) // Start at 1, not 0.
 
-        let artistText (track: FileTags) =
+        let artistText (track: LibraryTags) =
             if Array.isEmpty track.Artists
             then String.Empty
             else $"""{String.Join(", ", track.Artists)}  /  """

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -43,8 +43,9 @@ let private hasArtistOrTitle track =
 let private mainArtists (separator: string) (track: FileTags) =
     match track with
     | t when t.AlbumArtists.Length > 0
-             && t.AlbumArtists[0] <> "Various Artists"
-             && t.AlbumArtists[0] <> "Various" ->
+             && (t.AlbumArtists[0] <> "Various"
+             || t.AlbumArtists[0] <> "Various Artists"
+             || t.AlbumArtists[0] <> "Multiple Artists") ->
         t.AlbumArtists
     | t ->
         t.Artists

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -43,9 +43,9 @@ let private hasArtistOrTitle track =
 let private mainArtists (separator: string) (track: FileTags) =
     match track with
     | t when t.AlbumArtists.Length > 0
-             && (t.AlbumArtists[0] <> "Various"
-             || t.AlbumArtists[0] <> "Various Artists"
-             || t.AlbumArtists[0] <> "Multiple Artists") ->
+             && t.AlbumArtists[0] <> "Various"
+             && t.AlbumArtists[0] <> "Various Artists"
+             && t.AlbumArtists[0] <> "Multiple Artists" ->
         t.AlbumArtists
     | t ->
         t.Artists

--- a/src/AudioTagTools.GenreExtractor/Exporting.fs
+++ b/src/AudioTagTools.GenreExtractor/Exporting.fs
@@ -3,7 +3,7 @@ module Exporting
 open System
 open TagLibrary
 
-let private mainArtist (fileTags: FileTags) =
+let private mainArtist (fileTags: LibraryTags) =
     match fileTags with
     | a when a.Artists.Length > 0 -> a.Artists[0]
     | a when a.AlbumArtists.Length > 0 -> a.AlbumArtists[0]
@@ -20,7 +20,7 @@ let private mostCommon (items: string seq) : string =
     |> Option.map fst
     |> Option.defaultValue String.Empty
 
-let private allGenres (fileTags: FileTags array) : string array =
+let private allGenres (fileTags: LibraryTags array) : string array =
     fileTags
     |> Array.map _.Genres
     |> Array.filter (fun gs -> gs.Length > 0)
@@ -28,10 +28,10 @@ let private allGenres (fileTags: FileTags array) : string array =
 
 let private mostCommonGenres = allGenres >> mostCommon
 
-let getArtistsWithGenres (filesTagCollection: FileTagCollection) =
+let getArtistsWithGenres (allFileTags: LibraryTags array) =
     let separator = "＼" // Should be a character unlikely to appear in files' tags.
 
-    filesTagCollection
+    allFileTags
     |> Array.groupBy mainArtist
     |> Array.filter (fun (a, _) -> a <> String.Empty) // Maybe need tag check too.
     |> Array.map (fun (a, ts) -> a, mostCommonGenres ts)

--- a/src/AudioTagTools.GenreExtractor/IO.fs
+++ b/src/AudioTagTools.GenreExtractor/IO.fs
@@ -9,8 +9,8 @@ let readFile (fileInfo: FileInfo) : Result<string, Error> =
     readFile fileInfo
     |> Result.mapError IoReadError
 
-let parseToTags (json: string) : Result<FileTagCollection, Error> =
-    parseToTags json
+let parseJsonToTags (json: string) : Result<LibraryTags array, Error> =
+    parseJsonToTags json
     |> Result.mapError TagParseError
 
 let writeLines (filePath: string) (lines: string array) : Result<unit, Error> =

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -15,7 +15,7 @@ let private run (args: string array) : Result<unit, Error> =
         let! output =
             tagLibraryFile
             |> IO.readFile
-            >>= IO.parseToTags
+            >>= IO.parseJsonToTags
             <.> fun tags -> printfn $"Parsed tags for {formatInt tags.Length} files from the tag library."
             <!> getArtistsWithGenres
             <.> fun xs -> printfn $"Prepared {formatInt xs.Length} artist-genre pairs."

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -9,6 +9,8 @@ open Shared.IO
 open FsToolkit.ErrorHandling
 
 let private run (args: string array) : Result<unit, Error> =
+    printfn "Starting..."
+
     result {
         let! tagLibraryFile, genreFile = validate args
 

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -9,8 +9,6 @@ open Shared.IO
 open FsToolkit.ErrorHandling
 
 let private run (args: string array) : Result<unit, Error> =
-    printfn "Starting..."
-
     result {
         let! tagLibraryFile, genreFile = validate args
 

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -1,30 +1,24 @@
 module TagLibrary
 
-open FSharp.Data
+open System
+open System.Text.Json
 
-[<Literal>]
-let private tagSample = """
-[
-  {
-    "FileNameOnly": "text",
-    "DirectoryName": "text",
-    "Artists": ["text"],
-    "AlbumArtists": ["text"],
-    "Album": "text",
-    "TrackNo": 0,
-    "Title": "text",
-    "Year": 0,
-    "Genres": ["text"],
-    "Duration": "00:00:00",
-    "LastWriteTime": "2023-09-13T13:49:44+09:00"
-  }
-]"""
+type LibraryTags =
+    {
+        FileNameOnly: string
+        DirectoryName: string
+        Artists: string array
+        AlbumArtists: string array
+        Album: string
+        TrackNo: uint
+        Title: string
+        Year: uint
+        Genres: string array
+        Duration: TimeSpan
+        LastWriteTime: DateTimeOffset
+    }
 
-type TagJsonProvider = JsonProvider<tagSample>
-type FileTags = TagJsonProvider.Root
-type FileTagCollection = FileTags array
-type FilteredTagCollection = FileTags array
+let parseJsonToTags (json: string) : Result<LibraryTags array, string> =
+    try Ok (JsonSerializer.Deserialize<LibraryTags array>(json))
+    with e -> Error e.Message
 
-let parseToTags (json: string) : Result<FileTagCollection, string> =
-    try Ok (TagJsonProvider.Parse json)
-    with ex -> Error ex.Message


### PR DESCRIPTION
- Primary
    - Add a try-with block to the tag-reading operation
- Secondary
    - Add "Starting..." messages when starting operations
    - Remove superfluous computation expression
    - Other minor cleanup, nomenclature updates, etc.