### PR TITLE
Add sample rate, bitrate, and file size to cached data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ Ensure you are in the `AudioTagTools.Console` directory in your terminal.
 
 ## Caching tags
 
-Creates a tag library, a JSON file containing the text tag data from the audio files in a specified directory. 
+Creates a tag library, a JSON file containing the text tag data from the audio files in a specified directory.
+
+> [!NOTE]
+> If you have many files, especially on an external device, this process might take a while on its initial run, but will be much faster in subsequent ones. 
 
 Pass `cache-tags` with two arguments:
 

--- a/README.md
+++ b/README.md
@@ -184,3 +184,14 @@ dotnet run -- export-genres ~/Downloads/Music/tagLibrary.json ~/Downloads/Music/
 ```
 
 If a genres file already exists at that path, a backup will be created automatically.
+
+## Exit codes
+
+The program returns the following exit codes:
+
+| Code | Meaning                                |
+|------|----------------------------------------|
+| 0    | Finished without issue                 |
+| 1    | Invalid argument count                 |
+| 2    | Invalid command                        |
+| 3    | Failure during the requested operation |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The file will be in this JSON format:
 ```json
 [
   {
-    "FileNameOnly": "FILENAME.m4a",
+    "FileName": "FILENAME.m4a",
     "DirectoryName": "FULL_DIRECTORY_NAME",
     "Artists": [
       "SAMPLE ARTIST NAME"

--- a/src/AudioTagTools.Cacher/Errors.fs
+++ b/src/AudioTagTools.Cacher/Errors.fs
@@ -6,16 +6,18 @@ type Error =
     | ReadFileError of string
     | WriteFileError of string
     | GeneralIoError of string
+    | NoFilesFound of string
     | LibraryTagParseError of string
     | FileTagParseError of string
     | JsonSerializationError of string
 
 let message = function
     | InvalidArgCount -> "Invalid arguments. Pass in (1) the directory containing your audio files and (2) a path to a JSON file containing cached tag data."
-    | MediaDirectoryMissing msg -> $"Directory \"{msg}\" was not found."
+    | MediaDirectoryMissing dir -> $"Directory \"{dir}\" was not found."
     | ReadFileError msg -> $"Read failure: {msg}"
     | WriteFileError msg -> $"Write failure: {msg}"
     | GeneralIoError msg -> $"I/O failure: {msg}"
+    | NoFilesFound dir -> $"No files found in \"{dir}\"."
     | LibraryTagParseError msg -> $"Library tag parse error: {msg}"
     | FileTagParseError msg -> $"File tag parse error: {msg}"
     | JsonSerializationError msg -> $"JSON serialization error: {msg}"

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -14,9 +14,10 @@ let readfile filePath : Result<string, Error> =
 
 let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
     let isSupportedAudioFile (fileInfo: FileInfo) =
-        // Supported formats from https://github.com/mono/taglib-sharp.
-        ["aa"; "aax"; "aac"; "aiff"; "ape"; "dsf"; "flac"; "m4a"; "m4b"; "m4p"
-         "mp3"; "mpc"; "mpp"; "ogg"; "oga"; "wav"; "wma"; "wv"; "webm"]
+        // Supported file format extensions from https://github.com/mono/taglib-sharp.
+        // The initial periods are needed.
+        [".aa"; ".aax"; ".aac"; ".aiff"; ".ape"; ".dsf"; ".flac"; ".m4a"; ".m4b"; "m4p"
+         ".mp3"; ".mpc"; ".mpp"; ".ogg"; ".oga"; ".wav"; ".wma"; ".wv"; ".webm"]
         |> List.contains fileInfo.Extension
 
     try

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -17,7 +17,7 @@ let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
         // Supported file format extensions from https://github.com/mono/taglib-sharp.
         // The initial periods are needed.
         [".aa"; ".aax"; ".aac"; ".aiff"; ".ape"; ".dsf"; ".flac"; ".m4a"; ".m4b"; "m4p"
-         ".mp3"; ".mpc"; ".mpp"; ".ogg"; ".oga"; ".wav"; ".wma"; ".wv"; ".webm"]
+         ".mp3"; ".mp4"; ".mpc"; ".mpp"; ".ogg"; ".oga"; ".wav"; ".wma"; ".wv"; ".webm"]
         |> List.contains (fileInfo.Extension.ToLowerInvariant())
 
     try

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -14,7 +14,9 @@ let readfile filePath : Result<string, Error> =
 
 let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
     let isSupportedAudioFile (fileInfo: FileInfo) =
-        [".mp3"; ".m4a"; ".mp4"; ".ogg"; ".flac"]
+        // Supported formats from https://github.com/mono/taglib-sharp.
+        ["aa"; "aax"; "aac"; "aiff"; "ape"; "dsf"; "flac"; "m4a"; "m4b"; "m4p"
+         "mp3"; "mpc"; "mpp"; "ogg"; "oga"; "wav"; "wma"; "wv"; "webm"]
         |> List.contains fileInfo.Extension
 
     try

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -18,12 +18,15 @@ let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
         // The initial periods are needed.
         [".aa"; ".aax"; ".aac"; ".aiff"; ".ape"; ".dsf"; ".flac"; ".m4a"; ".m4b"; "m4p"
          ".mp3"; ".mpc"; ".mpp"; ".ogg"; ".oga"; ".wav"; ".wma"; ".wv"; ".webm"]
-        |> List.contains fileInfo.Extension
+        |> List.contains (fileInfo.Extension.ToLowerInvariant())
 
     try
         dirPath.EnumerateFiles("*", SearchOption.AllDirectories)
         |> Seq.filter isSupportedAudioFile
-        |> Ok
+        |> fun files ->
+            if Seq.isEmpty files
+            then Error (NoFilesFound dirPath.FullName)
+            else Ok files
     with
     | e -> Error (GeneralIoError e.Message)
 

--- a/src/AudioTagTools.Cacher/IO.fs
+++ b/src/AudioTagTools.Cacher/IO.fs
@@ -14,10 +14,11 @@ let readfile filePath : Result<string, Error> =
 
 let getFileInfos (dirPath: DirectoryInfo) : Result<FileInfo seq, Error> =
     let isSupportedAudioFile (fileInfo: FileInfo) =
-        // Supported file format extensions from https://github.com/mono/taglib-sharp.
-        // The initial periods are needed.
+        // Supported file format extensions from https://github.com/mono/taglib-sharp,
+        // plus some additional ones. Initial periods are needed.
         [".aa"; ".aax"; ".aac"; ".aiff"; ".ape"; ".dsf"; ".flac"; ".m4a"; ".m4b"; "m4p"
-         ".mp3"; ".mp4"; ".mpc"; ".mpp"; ".ogg"; ".oga"; ".wav"; ".wma"; ".wv"; ".webm"]
+         ".mp3"; ".mpc"; ".mpp"; ".ogg"; ".oga"; ".wav"; ".wma"; ".wv"; ".webm"
+         ".mp4"; ".opus"; ] // This line contains additional custom ones.
         |> List.contains (fileInfo.Extension.ToLowerInvariant())
 
     try

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -15,7 +15,7 @@ let private run (args: string array) : Result<unit, Error> =
         let! tagLibraryMap = createTagLibraryMap tagLibraryFile
         let! newJson = generateNewJson tagLibraryMap fileInfos
 
-        let! _ =
+        do!
             copyToBackupFile tagLibraryFile
             |> Result.mapError WriteFileError
 

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -15,12 +15,16 @@ let private run (args: string array) : Result<unit, Error> =
         let! tagLibraryMap = createTagLibraryMap tagLibraryFile
         let! newJson = generateNewJson tagLibraryMap fileInfos
 
-        do!
-            copyToBackupFile tagLibraryFile
+        let _ =
+            tagLibraryFile
+            |> copyToBackupFile
+            |> Result.tee (fun backupFile -> printfn "Backed up previous file to \"%s\"." backupFile.Name)
             |> Result.mapError WriteFileError
 
         do!
-            writeTextToFile tagLibraryFile.FullName newJson
+            newJson
+            |> writeTextToFile tagLibraryFile.FullName
+            |> Result.tee (fun _ -> printfn "Wrote file \"%s\"." tagLibraryFile.FullName)
             |> Result.mapError WriteFileError
     }
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -40,21 +40,9 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
     : CategorizedTagsToCache seq
     =
     let copyCachedTags (libraryTags: LibraryTags) =
-        {
-            FileNameOnly = libraryTags.FileNameOnly
-            DirectoryName = libraryTags.DirectoryName
-            Artists = libraryTags.Artists
-            AlbumArtists = libraryTags.AlbumArtists
-            Album = libraryTags.Album
-            TrackNo = uint libraryTags.TrackNo
-            Title = libraryTags.Title
-            Year = uint libraryTags.Year
-            Genres = libraryTags.Genres
-            Duration = libraryTags.Duration
-            LastWriteTime = DateTimeOffset libraryTags.LastWriteTime.DateTime
-        }
+        { libraryTags with LastWriteTime = DateTimeOffset libraryTags.LastWriteTime.DateTime }
 
-    let generateTags (fileInfo: FileInfo) : LibraryTags =
+    let generateNewTags (fileInfo: FileInfo) : LibraryTags =
         let blankTags =
             {
                 FileNameOnly = fileInfo.Name
@@ -67,6 +55,8 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 Year = 0u
                 Genres = [| String.Empty |]
                 Duration = TimeSpan.Zero
+                BitRate = 0
+                SampleRate = 0
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
@@ -88,6 +78,8 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 Year = fileTags.Tag.Year
                 Genres = fileTags.Tag.Genres
                 Duration = fileTags.Properties.Duration
+                BitRate = fileTags.Properties.AudioBitrate
+                SampleRate = fileTags.Properties.AudioSampleRate
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
@@ -100,9 +92,9 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
         then
             let libraryTags = Map.find audioFile.FullName tagLibraryMap
             if libraryTags.LastWriteTime.DateTime < audioFile.LastWriteTime
-            then { Type = OutOfDate; Tags = (generateTags audioFile) }
+            then { Type = OutOfDate; Tags = (generateNewTags audioFile) }
             else { Type = Unchanged; Tags = (copyCachedTags libraryTags) }
-        else { Type = NotPresent; Tags = (generateTags audioFile) }
+        else { Type = NotPresent; Tags = (generateNewTags audioFile) }
 
     fileInfos
     |> Seq.map (prepareTagsToCache tagLibraryMap)

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -1,7 +1,6 @@
 module Tags
 
 open System
-open System.Text.Json
 open IO
 open Errors
 open Operators

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -23,7 +23,7 @@ type CategorizedTagsToCache =
 let createTagLibraryMap (libraryFile: FileInfo) : Result<TagMap, Error> =
 
     let audioFilePath (fileTags: LibraryTags) : string =
-        Path.Combine [| fileTags.DirectoryName; fileTags.FileNameOnly |]
+        Path.Combine [| fileTags.DirectoryName; fileTags.FileName |]
 
     if libraryFile.Exists
     then
@@ -44,13 +44,14 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
     let generateNewTags (fileInfo: FileInfo) : LibraryTags =
        let tagsFromFile (fileInfo: FileInfo) (fileTags: FileTags) =
             {
-                FileNameOnly = fileInfo.Name
+                FileName = fileInfo.Name
                 DirectoryName = fileInfo.DirectoryName
                 Artists = fileTags.Tag.Performers |> Array.map _.Normalize()
                 AlbumArtists = fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
                 Album = match fileTags.Tag.Album with
                         | null  -> String.Empty
                         | album -> album.Normalize()
+                DiscNo = fileTags.Tag.Disc
                 TrackNo = fileTags.Tag.Track
                 Title = match fileTags.Tag.Title with
                         | null  -> String.Empty
@@ -61,6 +62,7 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 BitRate = fileTags.Properties.AudioBitrate
                 SampleRate = fileTags.Properties.AudioSampleRate
                 FileSize = fileInfo.Length
+                ImageCount = fileTags.Tag.Pictures.Length
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -48,15 +48,13 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 DirectoryName = fileInfo.DirectoryName
                 Artists = fileTags.Tag.Performers |> Array.map _.Normalize()
                 AlbumArtists = fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
-                Album = fileTags.Tag.Album
-                        |> Option.ofObj
-                        |> Option.map _.Normalize()
-                        |> Option.defaultValue String.Empty
+                Album = match fileTags.Tag.Album with
+                        | null  -> String.Empty
+                        | album -> album.Normalize()
                 TrackNo = fileTags.Tag.Track
-                Title = fileTags.Tag.Title
-                        |> Option.ofObj
-                        |> Option.map _.Normalize()
-                        |> Option.defaultValue String.Empty
+                Title = match fileTags.Tag.Title with
+                        | null  -> String.Empty
+                        | title -> title.Normalize()
                 Year = fileTags.Tag.Year
                 Genres = fileTags.Tag.Genres
                 Duration = fileTags.Properties.Duration

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -57,6 +57,7 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 Duration = TimeSpan.Zero
                 BitRate = 0
                 SampleRate = 0
+                FileSize = 0
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
@@ -80,6 +81,7 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 Duration = fileTags.Properties.Duration
                 BitRate = fileTags.Properties.AudioBitrate
                 SampleRate = fileTags.Properties.AudioSampleRate
+                FileSize = fileInfo.Length
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -9,7 +9,6 @@ open Utilities
 open FsToolkit.ErrorHandling
 open TagLibrary
 
-
 type TagMap = Map<string, LibraryTags>
 
 type LibraryComparisonResult =
@@ -43,25 +42,7 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
         { libraryTags with LastWriteTime = DateTimeOffset libraryTags.LastWriteTime.DateTime }
 
     let generateNewTags (fileInfo: FileInfo) : LibraryTags =
-        let blankTags =
-            {
-                FileNameOnly = fileInfo.Name
-                DirectoryName = fileInfo.DirectoryName
-                Artists = [| String.Empty |]
-                AlbumArtists = [| String.Empty |]
-                Album = String.Empty
-                TrackNo = 0u
-                Title = String.Empty
-                Year = 0u
-                Genres = [| String.Empty |]
-                Duration = TimeSpan.Zero
-                BitRate = 0
-                SampleRate = 0
-                FileSize = 0
-                LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
-            }
-
-        let tagsFromFile (fileInfo: FileInfo) (fileTags: FileTags) =
+       let tagsFromFile (fileInfo: FileInfo) (fileTags: FileTags) =
             {
                 FileNameOnly = fileInfo.Name
                 DirectoryName = fileInfo.DirectoryName
@@ -85,9 +66,9 @@ let private prepareTagsToWrite (tagLibraryMap: TagMap) (fileInfos: FileInfo seq)
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
-        match parseFileTags fileInfo.FullName with
-        | Ok (Some tags) -> tagsFromFile fileInfo tags
-        | _ -> blankTags
+       match parseFileTags fileInfo.FullName with
+       | Ok (Some tags) -> tagsFromFile fileInfo tags
+       | _ -> blankTags fileInfo
 
     let prepareTagsToCache (tagLibraryMap: TagMap) (audioFile: FileInfo) : CategorizedTagsToCache =
         if Map.containsKey audioFile.FullName tagLibraryMap

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -26,7 +26,7 @@ let savePlaylist (settings: SettingsRoot) (tags: LibraryTags array array option)
         let extInf = $"#EXTINF:{seconds},{artistWithTitle}"
         builder.AppendLine extInf |> ignore
 
-        let fullPath = Path.Combine(m.DirectoryName, m.FileNameOnly)
+        let fullPath = Path.Combine(m.DirectoryName, m.FileName)
 
         let updatedPath =
             match settings.Playlist.SearchPath, settings.Playlist.ReplacePath with

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -41,11 +41,14 @@ let private hasArtistOrTitle track =
     hasAnyArtist track && hasTitle track
 
 let private mainArtists (separator: string) (track: LibraryTags) =
+    let noForbiddenAlbumArtists artist =
+        [| String.Empty; "Various"; "Various Artists"; "Multiple Artists" |]
+        |> Array.exists _.Equals(artist, StringComparison.InvariantCultureIgnoreCase)
+        |> not
+
     match track with
     | t when t.AlbumArtists.Length > 0
-             && t.AlbumArtists[0] <> "Various"
-             && t.AlbumArtists[0] <> "Various Artists"
-             && t.AlbumArtists[0] <> "Multiple Artists" ->
+             && noForbiddenAlbumArtists t.AlbumArtists[0] ->
         t.AlbumArtists
     | t ->
         t.Artists

--- a/src/AudioTagTools.Shared/IO.fs
+++ b/src/AudioTagTools.Shared/IO.fs
@@ -10,12 +10,18 @@ let readFile (fileInfo: FileInfo) : Result<string, string> =
         |> Ok
     with ex -> Error ex.Message
 
-let writeTextToFile (filePath: string) (text: string) : Result<unit, string> =
-    try Ok (File.WriteAllText(filePath, text))
+let writeTextToFile (writePath: string) (text: string) : Result<unit, string> =
+    try
+        (writePath, text)
+        |> File.WriteAllText
+        |> Ok
     with ex -> Error ex.Message
 
-let writeLinesToFile (filePath: string) (lines: string array) : Result<unit, string> =
-    try Ok (File.WriteAllLines(filePath, lines))
+let writeLinesToFile (writePath: string) (lines: string array) : Result<unit, string> =
+    try
+        (writePath, lines)
+        |> File.WriteAllLines
+        |> Ok
     with ex -> Error ex.Message
 
 let copyToBackupFile (tagLibrary: FileInfo) : Result<FileInfo, string> =
@@ -33,5 +39,4 @@ let copyToBackupFile (tagLibrary: FileInfo) : Result<FileInfo, string> =
             generateBackUpFilePath()
             |> tagLibrary.CopyTo
             |> Ok
-        with
-        | ex -> Error ex.Message
+        with ex -> Error ex.Message

--- a/src/AudioTagTools.Shared/IO.fs
+++ b/src/AudioTagTools.Shared/IO.fs
@@ -18,7 +18,7 @@ let writeLinesToFile (filePath: string) (lines: string array) : Result<unit, str
     try Ok (File.WriteAllLines(filePath, lines))
     with ex -> Error ex.Message
 
-let copyToBackupFile (fileInfo: FileInfo) : Result<FileInfo option, string> =
+let copyToBackupFile (fileInfo: FileInfo) : Result<unit, string> =
     let generateBackUpFilePath (tagLibraryFile: FileInfo) : string =
         let baseName = Path.GetFileNameWithoutExtension tagLibraryFile.Name
         let timestamp = DateTimeOffset.Now.ToString "yyyyMMdd_HHmmss"
@@ -37,8 +37,8 @@ let copyToBackupFile (fileInfo: FileInfo) : Result<FileInfo option, string> =
             |> generateBackUpFilePath
             |> fileInfo.CopyTo
             |> printConfirmation
-            |> Some
+            |> ignore
             |> Ok
         with
         | ex -> Error ex.Message
-    else Ok None
+    else Error "Source file does not exist, so it cannot be backed up."

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -16,6 +16,8 @@ type LibraryTags =
         Genres: string array
         Duration: TimeSpan
         LastWriteTime: DateTimeOffset
+        BitRate: int
+        SampleRate: int
     }
 
 let parseJsonToTags (json: string) : Result<LibraryTags array, string> =

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -18,6 +18,7 @@ type LibraryTags =
         LastWriteTime: DateTimeOffset
         BitRate: int
         SampleRate: int
+        FileSize: int64
     }
 
 let parseJsonToTags (json: string) : Result<LibraryTags array, string> =

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -44,7 +44,6 @@ let blankTags (fileInfo: FileInfo) : LibraryTags =
         LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
     }
 
-
 let parseJsonToTags (json: string) : Result<LibraryTags array, string> =
     try Ok (JsonSerializer.Deserialize<LibraryTags array>(json))
     with e -> Error e.Message

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -40,7 +40,7 @@ let blankTags (fileInfo: FileInfo) : LibraryTags =
         BitRate = 0
         SampleRate = 0
         FileSize = 0
-        ImageCount = 1
+        ImageCount = 0
         LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
     }
 

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -6,11 +6,12 @@ open System.Text.Json
 
 type LibraryTags =
     {
-        FileNameOnly: string
+        FileName: string
         DirectoryName: string
         Artists: string array
         AlbumArtists: string array
         Album: string
+        DiscNo: uint
         TrackNo: uint
         Title: string
         Year: uint
@@ -19,16 +20,18 @@ type LibraryTags =
         BitRate: int
         SampleRate: int
         FileSize: int64
+        ImageCount: int
         LastWriteTime: DateTimeOffset
     }
 
 let blankTags (fileInfo: FileInfo) : LibraryTags =
     {
-        FileNameOnly = fileInfo.Name
+        FileName = fileInfo.Name
         DirectoryName = fileInfo.DirectoryName
         Artists = [| String.Empty |]
         AlbumArtists = [| String.Empty |]
         Album = String.Empty
+        DiscNo = 0u
         TrackNo = 0u
         Title = String.Empty
         Year = 0u
@@ -37,6 +40,7 @@ let blankTags (fileInfo: FileInfo) : LibraryTags =
         BitRate = 0
         SampleRate = 0
         FileSize = 0
+        ImageCount = 1
         LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
     }
 

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -1,6 +1,7 @@
 module TagLibrary
 
 open System
+open System.IO
 open System.Text.Json
 
 type LibraryTags =
@@ -20,6 +21,25 @@ type LibraryTags =
         SampleRate: int
         FileSize: int64
     }
+
+let blankTags (fileInfo: FileInfo) : LibraryTags =
+    {
+        FileNameOnly = fileInfo.Name
+        DirectoryName = fileInfo.DirectoryName
+        Artists = [| String.Empty |]
+        AlbumArtists = [| String.Empty |]
+        Album = String.Empty
+        TrackNo = 0u
+        Title = String.Empty
+        Year = 0u
+        Genres = [| String.Empty |]
+        Duration = TimeSpan.Zero
+        BitRate = 0
+        SampleRate = 0
+        FileSize = 0
+        LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
+    }
+
 
 let parseJsonToTags (json: string) : Result<LibraryTags array, string> =
     try Ok (JsonSerializer.Deserialize<LibraryTags array>(json))

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -16,10 +16,10 @@ type LibraryTags =
         Year: uint
         Genres: string array
         Duration: TimeSpan
-        LastWriteTime: DateTimeOffset
         BitRate: int
         SampleRate: int
         FileSize: int64
+        LastWriteTime: DateTimeOffset
     }
 
 let blankTags (fileInfo: FileInfo) : LibraryTags =


### PR DESCRIPTION
- Add files' sample rates, bitrates, and sizes to the tag library
- Show an error if no files are found when attempting to cache tags
- Expand the number of supported file formats (based mostly on TagLibSharp's own list)
- Other minor cleanup and tweaks
- Includes updates from #14