### PR TITLE
Fix album artist–related regression in duplicate-finding

### DIFF
--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -41,12 +41,14 @@ let private hasArtistOrTitle track =
     hasAnyArtist track && hasTitle track
 
 let private mainArtists (separator: string) (track: LibraryTags) =
+    let noForbiddenAlbumArtists artist =
+        [| String.Empty; "Various"; "Various Artists"; "Multiple Artists" |]
+        |> Array.exists _.Equals(artist, StringComparison.InvariantCultureIgnoreCase)
+        |> not
+
     match track with
     | t when t.AlbumArtists.Length > 0
-             && t.AlbumArtists[0] <> String.Empty
-             && t.AlbumArtists[0] <> "Various"
-             && t.AlbumArtists[0] <> "Various Artists"
-             && t.AlbumArtists[0] <> "Multiple Artists" ->
+             && noForbiddenAlbumArtists t.AlbumArtists[0] ->
         t.AlbumArtists
     | t ->
         t.Artists

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -43,6 +43,7 @@ let private hasArtistOrTitle track =
 let private mainArtists (separator: string) (track: LibraryTags) =
     match track with
     | t when t.AlbumArtists.Length > 0
+             && t.AlbumArtists[0] <> String.Empty
              && t.AlbumArtists[0] <> "Various"
              && t.AlbumArtists[0] <> "Various Artists"
              && t.AlbumArtists[0] <> "Multiple Artists" ->


### PR DESCRIPTION
I discovered a regression in #11 that caused improper duplicates (false positives) to be included due to a problem with album artist checking. The better fix might be reworking the upgraded tag type to use `Option`s or some such, and I might look into that later, but this fix resolves the issue.