### PR TITLE
Ignore punctuation in duplicate checks

### DIFF
--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -48,10 +48,10 @@ let filter (settings: Settings) (allTags: MultipleLibraryTags) : MultipleLibrary
 /// (2) The track title.
 /// The string is intended to be used solely for track grouping.
 let private groupName (settings: Settings) fileTags =
-    let cleanText customSubStrs =
-        String.removeSubstrings customSubStrs
-        >> String.removeSubstrings String.whiteSpaces
-        >> String.removePunctuation
+    let scrubText subStrs =
+        String.stripSubstrings subStrs
+        >> String.stripSubstrings String.whiteSpaces
+        >> String.stripPunctuation
 
     let artist =
         let checkEquivalentArtists trackArtist =
@@ -62,13 +62,13 @@ let private groupName (settings: Settings) fileTags =
                | None -> trackArtist
 
         fileTags
-        |> mainArtists String.Empty // Separator unneeded since this text is for grouping only.
+        |> mainArtists String.Empty
         |> checkEquivalentArtists
-        |> cleanText settings.ArtistReplacements
+        |> scrubText settings.ArtistReplacements
 
     let title =
         fileTags.Title
-        |> cleanText settings.TitleReplacements
+        |> scrubText settings.TitleReplacements
 
     $"{artist}{title}"
         .Normalize(NormalizationForm.FormC)

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -49,8 +49,9 @@ let filter (settings: Settings) (allTags: MultipleLibraryTags) : MultipleLibrary
 /// The string is intended to be used solely for track grouping.
 let private groupName (settings: Settings) fileTags =
     let scrubText subStrs =
-        String.stripSubstrings subStrs
-        >> String.stripSubstrings String.whiteSpaces
+        [| String.whiteSpaces; subStrs |]
+        |> Array.concat
+        |> String.stripSubstrings
         >> String.stripPunctuation
 
     let artist =

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -49,8 +49,8 @@ let filter (settings: Settings) (allTags: MultipleLibraryTags) : MultipleLibrary
 /// The string is intended to be used solely for track grouping.
 let private groupName (settings: Settings) fileTags =
     let scrubText subStrs =
-        [| String.whiteSpaces; subStrs |]
-        |> Array.concat
+        subStrs
+        |> Array.append String.whiteSpaces
         |> String.stripSubstrings
         >> String.stripPunctuation
 

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -43,15 +43,15 @@ let filter (settings: Settings) (allTags: MultipleLibraryTags) : MultipleLibrary
 
 /// Returns a normalized string of two concatenated items:
 /// (1) The artist name that should be used for artist grouping when searching for duplicates.
-///     If the artist appears in any "equivalent artist" group, then the first equilavent artist
+///     If the artist appears in any "equivalent artist" group, then the first equivalent artist
 ///     name from that group will be prioritized over the track's artist name.
 /// (2) The track title.
 /// The string is intended to be used solely for track grouping.
 let private groupName (settings: Settings) fileTags =
-    let removeSubstrings subStrs =
-        subStrs
-        |> Array.append String.whiteSpaces
-        |> String.removeSubstrings
+    let cleanText customSubStrs =
+        String.removeSubstrings customSubStrs
+        >> String.removeSubstrings String.whiteSpaces
+        >> String.removePunctuation
 
     let artist =
         let checkEquivalentArtists trackArtist =
@@ -64,11 +64,11 @@ let private groupName (settings: Settings) fileTags =
         fileTags
         |> mainArtists String.Empty // Separator unneeded since this text is for grouping only.
         |> checkEquivalentArtists
-        |> removeSubstrings settings.ArtistReplacements
+        |> cleanText settings.ArtistReplacements
 
     let title =
         fileTags.Title
-        |> removeSubstrings settings.TitleReplacements
+        |> cleanText settings.TitleReplacements
 
     $"{artist}{title}"
         .Normalize(NormalizationForm.FormC)

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -58,9 +58,8 @@ let private groupName (settings: Settings) fileTags =
         let checkEquivalentArtists trackArtist =
             settings.EquivalentArtists
             |> Array.tryFind (Array.contains trackArtist)
-            |> function
-               | Some eqArtists -> eqArtists[0]
-               | None -> trackArtist
+            |> Option.map Array.head
+            |> Option.defaultValue trackArtist
 
         fileTags
         |> mainArtists String.Empty

--- a/src/AudioTagTools.Shared/Common.fs
+++ b/src/AudioTagTools.Shared/Common.fs
@@ -163,7 +163,7 @@ module String =
         ofTry (fun _ -> JsonSerializer.Serialize(items, options))
 
     /// Removes all instances of multiple substrings from a given string.
-    let removeSubstrings (substrings: string array) (text: string) : string =
+    let stripSubstrings (substrings: string array) (text: string) : string =
         Array.fold
             (fun acc x -> acc.Replace(x, String.Empty, StringComparison.InvariantCultureIgnoreCase))
             text
@@ -196,7 +196,7 @@ module String =
             "\uFEFF" // zero-width non-breaking space
         |]
 
-    let removePunctuation (text: string) : string =
+    let stripPunctuation (text: string) : string =
         text.ToCharArray()
         |> Array.filter (not << Char.IsPunctuation)
         |> String

--- a/src/AudioTagTools.Shared/Common.fs
+++ b/src/AudioTagTools.Shared/Common.fs
@@ -195,6 +195,11 @@ module String =
             "\uFEFF" // zero-width non-breaking space
         |]
 
+    let removePunctuation (text: string) : string =
+        text.ToCharArray()
+        |> Array.filter (not << Char.IsPunctuation)
+        |> String
+
 [<RequireQualifiedAccess>]
 module Seq =
 

--- a/src/AudioTagTools.Shared/Common.fs
+++ b/src/AudioTagTools.Shared/Common.fs
@@ -27,6 +27,7 @@ module Numerics =
         when ^T : (member ToString : string * IFormatProvider -> string) =
         (^T : (member ToString : string * IFormatProvider -> string) (i, "#,##0", CultureInfo.InvariantCulture))
 
+[<RequireQualifiedAccess>]
 module String =
 
     let newLine = Environment.NewLine


### PR DESCRIPTION
- Leverage the [`Char.IsPunctuation()`](https://learn.microsoft.com/en-us/dotnet/api/system.char.ispunctuation?view=net-10.0) method to increase the accuracy of duplicate checks!
- Add the `[<RequireQualifiedAccess>]` attribute to my String module