### PR TITLE
Use F#+ applicative computation expressions

### DIFF
--- a/src/AudioTagTools.Cacher/ArgValidation.fs
+++ b/src/AudioTagTools.Cacher/ArgValidation.fs
@@ -9,9 +9,10 @@ open System.IO
 let validate args : Result<(DirectoryInfo * FileInfo), Error> =
     match args with
     | [| mediaDirArg; tagLibArg |] ->
-        (fun mediaDir -> (mediaDir, FileInfo tagLibArg))
-        <!> (mediaDirArg |> validateToDirInfo (MediaDirectoryMissing mediaDirArg))
+        applicative {
+            let! mediaDir = mediaDirArg |> validateToDirInfo (MediaDirectoryMissing mediaDirArg)
+            return (mediaDir, FileInfo tagLibArg)
+        }
         |> Validation.toResult
     | _ ->
         Error InvalidArgCount
-

--- a/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
+++ b/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
@@ -16,12 +16,12 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.32" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.33" />
       <PackageReference Include="FSharp.Data" Version="6.6.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.1.0" />
       <PackageReference Include="TagLibSharp" Version="2.3.0" />
-      <PackageReference Update="FSharp.Core" Version="10.0.102" />
+      <PackageReference Update="FSharp.Core" Version="10.0.103" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
+++ b/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
@@ -13,11 +13,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.32" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.33" />
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.1.0" />
-      <PackageReference Update="FSharp.Core" Version="10.0.102" />
+      <PackageReference Update="FSharp.Core" Version="10.0.103" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
+++ b/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
@@ -3,6 +3,7 @@ module DuplicateFinder.ArgValidation
 open Errors
 open Shared.IO
 open CCFSharpUtils.Library
+open FSharpPlus
 open FSharpPlus.Data
 open FsToolkit.ErrorHandling
 open System.IO
@@ -10,11 +11,11 @@ open System.IO
 let validate args : Result<(FileInfo * FileInfo), Error> =
     match args with
     | [| settingsFileArg; tagLibArg |] ->
-        Validation.map2
-            (fun settingsFile tagLib -> settingsFile, tagLib)
-            (settingsFileArg |> validateToFileInfo $"Settings file \"{settingsFileArg}\" does not exist.")
-            (tagLibArg       |> validateToFileInfo $"Tag library file \"{tagLibArg}\" does not exist.")
+        applicative {
+            let! settingsFile = settingsFileArg |> validateToFileInfo $"Settings file \"{settingsFileArg}\" does not exist."
+            and! tagLib = tagLibArg |> validateToFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
+            return (settingsFile, tagLib)
+        }
         |! (fun errs -> errs |> NonEmptyList.ofList |> IoFilesMissing)
     | _ ->
         Error ArgCountError
-

--- a/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
+++ b/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
@@ -7,6 +7,11 @@ open FSharpPlus
 open FSharpPlus.Data
 open System.IO
 
+let (||!) (v: Validation<'err1, 'ok>) (f: 'err1 -> 'err2) : Result<'ok, 'err2> =
+    v
+    |> Validation.toResult
+    |> Result.mapError f
+
 let validate args : Result<(FileInfo * FileInfo), Error> =
     match args with
     | [| settingsArg; tagLibArg |] ->
@@ -15,7 +20,6 @@ let validate args : Result<(FileInfo * FileInfo), Error> =
             and! tagLibFile = tagLibArg |> toFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
             return (settingsFile, tagLibFile)
         }
-        |> Validation.toResult
-        |! (NonEmptyList.ofList >> ArgErrors)
+        ||! (NonEmptyList.ofList >> ArgErrors)
     | _ ->
         Error ArgCountError

--- a/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
+++ b/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
@@ -5,17 +5,17 @@ open Shared.IO
 open CCFSharpUtils.Library
 open FSharpPlus
 open FSharpPlus.Data
-open FsToolkit.ErrorHandling
 open System.IO
 
 let validate args : Result<(FileInfo * FileInfo), Error> =
     match args with
-    | [| settingsFileArg; tagLibArg |] ->
+    | [| settingsArg; tagLibArg |] ->
         applicative {
-            let! settingsFile = settingsFileArg |> validateToFileInfo $"Settings file \"{settingsFileArg}\" does not exist."
-            and! tagLib = tagLibArg |> validateToFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
-            return (settingsFile, tagLib)
+            let! settingsFile = settingsArg |> toFileInfo $"Settings file \"{settingsArg}\" does not exist."
+            and! tagLibFile = tagLibArg |> toFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
+            return (settingsFile, tagLibFile)
         }
-        |! (fun errs -> errs |> NonEmptyList.ofList |> IoFilesMissing)
+        |> Validation.toResult
+        |! (NonEmptyList.ofList >> ArgErrors)
     | _ ->
         Error ArgCountError

--- a/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
+++ b/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
@@ -7,11 +7,6 @@ open FSharpPlus
 open FSharpPlus.Data
 open System.IO
 
-let (||!) (v: Validation<'err1, 'ok>) (f: 'err1 -> 'err2) : Result<'ok, 'err2> =
-    v
-    |> Validation.toResult
-    |> Result.mapError f
-
 let validate args : Result<(FileInfo * FileInfo), Error> =
     match args with
     | [| settingsArg; tagLibArg |] ->

--- a/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
+++ b/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
@@ -17,11 +17,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.32" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.33" />
       <PackageReference Include="FSharp.Data" Version="6.6.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.1.0" />
-      <PackageReference Update="FSharp.Core" Version="10.0.102" />
+      <PackageReference Update="FSharp.Core" Version="10.0.103" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AudioTagTools.DuplicateFinder/Errors.fs
+++ b/src/AudioTagTools.DuplicateFinder/Errors.fs
@@ -5,7 +5,7 @@ open FSharpPlus.Data
 
 type Error =
     | ArgCountError
-    | IoFilesMissing of string NonEmptyList
+    | ArgErrors of string NonEmptyList
     | IoFileReadError of string
     | IoFileWriteError of string
     | SettingsParseError of string
@@ -13,7 +13,7 @@ type Error =
 
 let message = function
     | ArgCountError -> "Invalid arguments. Pass in two JSON file paths: (1) your settings file and (2) your tag library."
-    | IoFilesMissing errs -> errs |> String.concatNL
+    | ArgErrors errs -> errs |> String.concatNL
     | IoFileReadError msg -> $"I/O read failure: {msg}"
     | IoFileWriteError msg -> $"I/O write failure: {msg}"
     | SettingsParseError msg -> $"Failure parsing settings file: {msg}"

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -4,6 +4,7 @@ open Errors
 open Settings
 open Shared
 open Shared.TagLibrary
+open FSharpPlus
 open CCFSharpUtils.Library
 open System
 open System.IO
@@ -59,7 +60,7 @@ let private groupName (settings: Settings) fileTags =
         let checkEquivalentArtists artist =
             settings.EquivalentArtists
             |> Array.tryFind (Array.contains artist)
-            |> Option.mapElse Array.head artist
+            |> option Array.head artist
 
         fileTags
         |> mainArtists String.Empty

--- a/src/AudioTagTools.GenreExtractor/ArgValidation.fs
+++ b/src/AudioTagTools.GenreExtractor/ArgValidation.fs
@@ -12,8 +12,7 @@ let validate args : Result<(FileInfo * FileInfo), Error> =
     | [| tagLibArg; genreFileArg |] ->
         applicative {
             let! tagLib = tagLibArg |> toFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
-            and! genreFile = genreFileArg |> toFileInfo $"Genre file \"{genreFileArg}\" does not exist."
-            return (tagLib, genreFile)
+            return (tagLib, FileInfo genreFileArg)
         }
         ||! (NonEmptyList.ofList >> ArgErrors)
     | _ ->

--- a/src/AudioTagTools.GenreExtractor/ArgValidation.fs
+++ b/src/AudioTagTools.GenreExtractor/ArgValidation.fs
@@ -3,6 +3,7 @@ module GenreExtractor.ArgValidation
 open Errors
 open Shared.IO
 open CCFSharpUtils.Library
+open FSharpPlus
 open FSharpPlus.Data
 open FsToolkit.ErrorHandling
 open System.IO
@@ -10,10 +11,11 @@ open System.IO
 let validate args : Result<(FileInfo * FileInfo), Error> =
     match args with
     | [| tagLibArg; genreFileArg |] ->
-        Validation.map2
-            (fun settingsFile tagLib -> settingsFile, tagLib)
-            (tagLibArg    |> validateToFileInfo $"Tag library file \"{tagLibArg}\" does not exist.")
-            (genreFileArg |> validateToFileInfo $"Genre file \"{genreFileArg}\" does not exist.")
+        applicative {
+            let! tagLib = tagLibArg |> validateToFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
+            and! genreFile = genreFileArg |> validateToFileInfo $"Genre file \"{genreFileArg}\" does not exist."
+            return (tagLib, genreFile)
+        }
         |! (fun errs -> errs |> NonEmptyList.ofList |> IoFilesMissing)
     | _ ->
         Error ArgCountError

--- a/src/AudioTagTools.GenreExtractor/ArgValidation.fs
+++ b/src/AudioTagTools.GenreExtractor/ArgValidation.fs
@@ -15,7 +15,6 @@ let validate args : Result<(FileInfo * FileInfo), Error> =
             and! genreFile = genreFileArg |> toFileInfo $"Genre file \"{genreFileArg}\" does not exist."
             return (tagLib, genreFile)
         }
-        |> Validation.toResult
-        |! (NonEmptyList.ofList >> ArgErrors)
+        ||! (NonEmptyList.ofList >> ArgErrors)
     | _ ->
         Error ArgCountError

--- a/src/AudioTagTools.GenreExtractor/ArgValidation.fs
+++ b/src/AudioTagTools.GenreExtractor/ArgValidation.fs
@@ -5,17 +5,17 @@ open Shared.IO
 open CCFSharpUtils.Library
 open FSharpPlus
 open FSharpPlus.Data
-open FsToolkit.ErrorHandling
 open System.IO
 
 let validate args : Result<(FileInfo * FileInfo), Error> =
     match args with
     | [| tagLibArg; genreFileArg |] ->
         applicative {
-            let! tagLib = tagLibArg |> validateToFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
-            and! genreFile = genreFileArg |> validateToFileInfo $"Genre file \"{genreFileArg}\" does not exist."
+            let! tagLib = tagLibArg |> toFileInfo $"Tag library file \"{tagLibArg}\" does not exist."
+            and! genreFile = genreFileArg |> toFileInfo $"Genre file \"{genreFileArg}\" does not exist."
             return (tagLib, genreFile)
         }
-        |! (fun errs -> errs |> NonEmptyList.ofList |> IoFilesMissing)
+        |> Validation.toResult
+        |! (NonEmptyList.ofList >> ArgErrors)
     | _ ->
         Error ArgCountError

--- a/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
+++ b/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
@@ -16,9 +16,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.32" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.33" />
       <PackageReference Include="FSharp.Data" Version="6.6.0" />
-      <PackageReference Update="FSharp.Core" Version="10.0.102" />
+      <PackageReference Update="FSharp.Core" Version="10.0.103" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
     </ItemGroup>
 

--- a/src/AudioTagTools.GenreExtractor/Errors.fs
+++ b/src/AudioTagTools.GenreExtractor/Errors.fs
@@ -5,14 +5,14 @@ open FSharpPlus.Data
 
 type Error =
     | ArgCountError
-    | IoFilesMissing of string NonEmptyList
-    | IoReadError of string
-    | IoWriteError of string
+    | ArgErrors of string NonEmptyList
+    | IoFileReadError of string
+    | IoFileWriteError of string
     | TagParseError of string
 
 let message = function
     | ArgCountError -> "Invalid arguments. Pass in (1) your tag library path and (2) the desired path for your exported genres file."
-    | IoFilesMissing errs -> errs |> String.concatNL
-    | IoReadError msg -> $"I/O read failure: {msg}"
-    | IoWriteError msg -> $"I/O write failure: {msg}"
+    | ArgErrors errs -> errs |> String.concatNL
+    | IoFileReadError msg -> $"I/O read failure: {msg}"
+    | IoFileWriteError msg -> $"I/O write failure: {msg}"
     | TagParseError msg -> $"Unable to parse the tag library file: {msg}"

--- a/src/AudioTagTools.GenreExtractor/Exporting.fs
+++ b/src/AudioTagTools.GenreExtractor/Exporting.fs
@@ -10,8 +10,13 @@ let private mainArtist (fileTags: LibraryTags) =
     | a when Array.isNotEmpty a.AlbumArtists -> a.AlbumArtists[0]
     | _ -> String.Empty
 
-let printOldSummary (oldGenres: string array) =
-    printfn "%s entries in the old file." (String.formatInt oldGenres.Length)
+let printOldSummary (oldGenres: string array) : unit =
+    match oldGenres with
+    | [||] ->
+        printfn "No existing genre data found."
+    | _  ->
+        let count = oldGenres.Length
+        printfn "%s %s in the old file." (String.formatInt count) (String.pluralize "entry" "entries" count)
 
 let printTagCount (tags: MultipleLibraryTags) =
     printfn $"Parsed tags for {String.formatInt tags.Length} files from the tag library."

--- a/src/AudioTagTools.GenreExtractor/IO.fs
+++ b/src/AudioTagTools.GenreExtractor/IO.fs
@@ -11,6 +11,12 @@ let readFile (fileInfo: FileInfo) : Result<string, Error> =
 let readLines (fileInfo: FileInfo) : Result<string array, Error> =
     readLines fileInfo |! IoFileReadError
 
+let readOldGenres (genreFile: FileInfo) : Result<string array, Error> =
+    if genreFile.Exists then
+        readLines genreFile
+    else
+        Ok Array.empty
+
 let writeLines (filePath: string) (lines: string array) : Result<unit, Error> =
     lines
     |> writeLinesToFile filePath

--- a/src/AudioTagTools.GenreExtractor/IO.fs
+++ b/src/AudioTagTools.GenreExtractor/IO.fs
@@ -11,7 +11,7 @@ let readFile (fileInfo: FileInfo) : Result<string, Error> =
 let readLines (fileInfo: FileInfo) : Result<string array, Error> =
     readLines fileInfo |! IoFileReadError
 
-let readOldGenres (genreFile: FileInfo) : Result<string array, Error> =
+let readGenres (genreFile: FileInfo) : Result<string array, Error> =
     if genreFile.Exists then
         readLines genreFile
     else

--- a/src/AudioTagTools.GenreExtractor/IO.fs
+++ b/src/AudioTagTools.GenreExtractor/IO.fs
@@ -6,17 +6,17 @@ open CCFSharpUtils.Library
 open System.IO
 
 let readFile (fileInfo: FileInfo) : Result<string, Error> =
-    readFile fileInfo |! IoReadError
+    readFile fileInfo |! IoFileReadError
 
 let readLines (fileInfo: FileInfo) : Result<string array, Error> =
-    readLines fileInfo |! IoReadError
+    readLines fileInfo |! IoFileReadError
 
 let writeLines (filePath: string) (lines: string array) : Result<unit, Error> =
     lines
     |> writeLinesToFile filePath
-    |! IoWriteError
+    |! IoFileWriteError
 
 let copyToBackupFile fileInfo : Result<FileInfo, Error> =
     fileInfo
     |> copyToBackupFile
-    |! IoWriteError
+    |! IoFileWriteError

--- a/src/AudioTagTools.GenreExtractor/IO.fs
+++ b/src/AudioTagTools.GenreExtractor/IO.fs
@@ -16,7 +16,11 @@ let writeLines (filePath: string) (lines: string array) : Result<unit, Error> =
     |> writeLinesToFile filePath
     |! IoFileWriteError
 
-let copyToBackupFile fileInfo : Result<FileInfo, Error> =
-    fileInfo
-    |> copyToBackupFile
-    |! IoFileWriteError
+let backupFileIfExists (fileInfo: FileInfo) : Result<string, Error> =
+    if fileInfo.Exists then
+        fileInfo
+        |> copyToBackupFile
+        |! IoFileWriteError
+        |> Result.map (fun fileInfo -> $"Created backup file \"{fileInfo}\".")
+    else
+        Ok $"File \"{fileInfo.FullName}\" does not exist, so no back up was done."

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -8,11 +8,20 @@ open Shared.TagLibrary
 open CCFSharpUtils.Library
 open FsToolkit.ErrorHandling
 
+let private separator = "＼"
+
 let private run args : Result<unit, Error> =
     result {
         let! tagLibraryFile, genreFile = validate args
 
-        let! oldGenres = readLines genreFile |. printOldSummary
+        let! oldGenres =
+            if genreFile.Exists then
+                genreFile
+                |> readLines
+                |. printOldSummary
+            else
+                printfn $"File \"{genreFile.FullName}\" will be created."
+                Ok Array.empty
 
         let! tags =
             tagLibraryFile
@@ -21,14 +30,14 @@ let private run args : Result<unit, Error> =
             |! TagParseError
 
         // The separator character should be rare and highly unlikely to appear in files' tags.
-        let newGenres = generateGenreData "＼" tags
+        let newGenres = tags |> generateGenreData separator
 
         printChanges oldGenres newGenres
 
         let! _ =
             genreFile
-            |> copyToBackupFile
-            |. fun fileInfo -> printfn $"Created backup file \"{fileInfo}\"."
+            |> backupFileIfExists
+            |. printfn "%s"
 
         return!
             newGenres

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -14,7 +14,7 @@ let private run args : Result<unit, Error> =
     result {
         let! tagLibraryFile, genreFile = validate args
 
-        let! oldGenres = genreFile |> readOldGenres |. printOldSummary
+        let! oldGenres = genreFile |> readGenres |. printOldSummary
 
         let! tags =
             tagLibraryFile

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -14,14 +14,7 @@ let private run args : Result<unit, Error> =
     result {
         let! tagLibraryFile, genreFile = validate args
 
-        let! oldGenres =
-            if genreFile.Exists then
-                genreFile
-                |> readLines
-                |. printOldSummary
-            else
-                printfn $"File \"{genreFile.FullName}\" will be created."
-                Ok Array.empty
+        let! oldGenres = genreFile |> readOldGenres |. printOldSummary
 
         let! tags =
             tagLibraryFile

--- a/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
+++ b/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
@@ -20,9 +20,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="10.0.102" />
+      <PackageReference Update="FSharp.Core" Version="10.0.103" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
-      <PackageReference Include="CCFSharpUtils" Version="0.1.32" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.33" />
     </ItemGroup>
 
 </Project>

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -14,11 +14,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.32" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.33" />
       <PackageReference Include="FSharp.Data" Version="6.6.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.1.0" />
-      <PackageReference Update="FSharp.Core" Version="10.0.102" />
+      <PackageReference Update="FSharp.Core" Version="10.0.103" />
       <PackageReference Include="Spectre.Console" Version="0.54.0" />
     </ItemGroup>
 

--- a/src/AudioTagTools.Shared/IO.fs
+++ b/src/AudioTagTools.Shared/IO.fs
@@ -58,10 +58,10 @@ let copyToBackupFile (tagLibrary: FileInfo) : Result<FileInfo, string> =
 
 /// If the file exists, returns its FileInfo wrapped in Ok. Otherwise, returns an error list.
 /// Intended to be used in applicative validation chains. (Thus, the list.)
-let validateToFileInfo (err: 'err) (file: string) : Result<FileInfo, 'err list> =
+let toFileInfo (err: 'err) (file: string) : Validation<'err list, FileInfo> =
     if File.Exists file
-    then Ok (FileInfo file)
-    else Error [err]
+    then Success (FileInfo file)
+    else Failure [err]
 
 /// If the directory exists, returns its DirectoryInfo wrapped in Success.
 /// Otherwise, returns the error wrapped in Failure.


### PR DESCRIPTION
- Use the `applicative` computation expression!
- Remove the unintentional requirement for an existing genres file during genre extraction, instead simply creating a new file if one does not exist