### PR TITLE
Remove MultipleLibraryTags type

### DIFF
--- a/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
+++ b/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.51" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.52" />
       <PackageReference Include="FSharp.Data" Version="8.1.3" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -18,17 +18,17 @@ let private run (args: string array) : Result<unit, CacherError> =
         let _ =
             tagLibraryFile
             |> backUpFile
-            |. fun backupFile -> printfn "Backed up previous file to \"%s\"." backupFile.Name
+            |. printfn "Backed up previous file to \"%O\"."
             |! FileWriteError
 
         do!
             newJson
             |> File.writeText' tagLibraryFile
-            |. fun _ -> printfn "Wrote file \"%s\"." tagLibraryFile.FullName
+            |. printfn "Wrote file \"%O{tagLibraryFile}\"."
             |! FileWriteError
     }
 
 let start (args: string array) : Result<string, string> =
     match run args with
-    | Ok () -> Ok "Finished caching successfully!"
+    | Ok ()   -> Ok "Finished caching successfully!"
     | Error e -> Error (message e)

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -22,12 +22,11 @@ type CategorizedTagsToCache =
 let createTagLibraryMap (libraryFile: FileInfo) : Result<LibraryTagMap, CacherError> =
     if libraryFile.Exists
     then
-        libraryFile.FullName
-        |>  File.readText
+        libraryFile
+        |>  File.readText'
         >>= parseToTags
-        |>> Array.map groupWithPath
-        |>> Map.ofArray
         |!  LibraryTagParseError
+        |>> (Array.map groupWithPath >> Map.ofArray)
     else
         Ok Map.empty
 

--- a/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
+++ b/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.51" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.52" />
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Console/Commands.fs
+++ b/src/AudioTagTools.Console/Commands.fs
@@ -13,12 +13,11 @@ let (|ValidCommand|InvalidCommand|) requestedCommand =
     commandMap
     |> Map.tryFind requestedCommand
     |> function
-    | Some command -> ValidCommand command
-    | None -> InvalidCommand
+       | Some command -> ValidCommand command
+       | None -> InvalidCommand
 
 let instructions =
     commandMap
     |> Map.keys
     |> String.concat "\" or \""
     |> sprintf "Supply a supported command: \"%s\"."
-

--- a/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
+++ b/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.51" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.52" />
       <PackageReference Include="FSharp.Data" Version="8.1.3" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -19,25 +19,25 @@ let savePlaylist
     let fileName = $"Duplicates by AudioTagTools - {now}.m3u"
     let file = FileInfo <| Path.Combine(settings.Playlist.SaveDirectory, fileName)
 
-    let appendFileEntry (builder: StringBuilder) (m: LibraryTags) : StringBuilder =
-        let seconds = m.Duration.TotalSeconds
+    let appendFileEntry (builder: StringBuilder) (t: LibraryTags) : StringBuilder =
+        let seconds = t.Duration.TotalSeconds
         let artist =
-            m.Artists
-            |> Array.append m.AlbumArtists
+            t.Artists
+            |> Array.append t.AlbumArtists
             |> String.concat "; "
-        let artistWithTitle = $"{artist} - {m.Title}"
+        let artistWithTitle = $"{artist} - {t.Title}"
         let extInf = $"#EXTINF:{seconds},{artistWithTitle}"
+
         builder.AppendLine extInf |> ignore
 
-        let oldPath = Path.Combine(m.DirectoryName, m.FileName)
-
-        let savePath =
+        let filePath =
+            let oldPath = Path.Combine(t.DirectoryName, t.FileName)
             match settings.Playlist.SearchPath,
                   settings.Playlist.ReplacePath with
             | s, _ when s |> String.hasNoText -> oldPath
             | s, r -> oldPath.Replace(s, r)
 
-        builder.AppendLine savePath
+        builder.AppendLine filePath
 
     match tags with
     | None -> Ok ()

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -5,13 +5,14 @@ open Settings
 open Shared.Constants
 open Shared.TagLibrary
 open CCFSharpUtils.Library
+open FSharpPlus.Data
 open System
 open System.Text
 open System.IO
 
 let savePlaylist
     (settings: Settings)
-    (tags: LibraryTags array array option)
+    (tags: LibraryTags array NonEmptyList option)
     : Result<unit, DupeFinderError> =
 
     let now = DateTime.Now.ToString timeStampFormat
@@ -42,9 +43,10 @@ let savePlaylist
     | None -> Ok ()
     | Some tags ->
         tags
-        |> Array.collect id
-        |> Array.fold appendFileEntry (StringBuilder "#EXTM3U\n")
-        |> _.ToString()
+        |> NonEmptyList.gather id
+        |> Seq.concat
+        |> Seq.fold appendFileEntry (StringBuilder "#EXTM3U\n")
+        |> string
         |> File.writeText' file
         |! FileWriteError
         |. fun _ -> printfn $"Created playlist file \"{file}\"."

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -19,7 +19,7 @@ let savePlaylist
     let fileName = $"Duplicates by AudioTagTools - {now}.m3u"
     let file = FileInfo <| Path.Combine(settings.Playlist.SaveDirectory, fileName)
 
-    let appendFileEntry (builder: StringBuilder) (t: LibraryTags) : StringBuilder =
+    let appendFileEntry (sb: StringBuilder) (t: LibraryTags) : StringBuilder =
         let seconds = t.Duration.TotalSeconds
         let artist =
             t.Artists
@@ -28,7 +28,7 @@ let savePlaylist
         let artistWithTitle = $"{artist} - {t.Title}"
         let extInf = $"#EXTINF:{seconds},{artistWithTitle}"
 
-        builder.AppendLine extInf |> ignore
+        sb.AppendLine extInf |> ignore
 
         let filePath =
             let oldPath = Path.Combine(t.DirectoryName, t.FileName)
@@ -37,7 +37,7 @@ let savePlaylist
             | s, _ when s |> String.hasNoText -> oldPath
             | s, r -> oldPath.Replace(s, r)
 
-        builder.AppendLine filePath
+        sb.AppendLine filePath
 
     match tags with
     | None -> Ok ()

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -11,7 +11,7 @@ open System.IO
 
 let savePlaylist
     (settings: Settings)
-    (tags: MultipleLibraryTags array option)
+    (tags: LibraryTags array array option)
     : Result<unit, DupeFinderError> =
 
     let now = DateTime.Now.ToString timeStampFormat

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -15,12 +15,12 @@ let private run (args: string array) : Result<unit, DupeFinderError> =
         let! settingsFile, tagLibraryFile = validate args
 
         let! settings = settingsFile |> File.readText' |! FileReadError >>= parseToSettings
-        let! tags = tagLibraryFile |> File.readText' |! FileReadError >>= parseToTags
+        let! libraryTags = tagLibraryFile |> File.readText' |! FileReadError >>= parseToTags
 
         printSummary settings
 
         let duplicates =
-           tags
+           libraryTags
            |> tap (printCount "Total file count:    ")
            |> discardExcluded settings
            |> tap (printCount "Filtered file count: ")
@@ -33,5 +33,5 @@ let private run (args: string array) : Result<unit, DupeFinderError> =
 
 let start args : Result<string, string> =
     match run args with
-    | Ok () -> Ok "Finished searching successfully."
+    | Ok ()   -> Ok "Finished searching successfully."
     | Error e -> Error (message e)

--- a/src/AudioTagTools.DuplicateFinder/Settings.fs
+++ b/src/AudioTagTools.DuplicateFinder/Settings.fs
@@ -40,12 +40,8 @@ type Settings = SettingsProvider.Root
 type Exclusion = SettingsProvider.Exclusion
 
 let parseToSettings (json: string) : Result<Settings, DupeFinderError> =
-    try
-        json
-        |> SettingsProvider.Parse
-        |> Ok
-    with
-    | e -> Error (SettingParseError e.Message)
+    try SettingsProvider.Parse json |> Ok
+    with e -> Error (SettingParseError e.Message)
 
 let printSummary (settings: Settings) =
     printfn "Settings:"

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -76,9 +76,9 @@ let findDuplicates settings (tags: LibraryTags array) : LibraryTags array NonEmp
     tags
     |> Array.filter hasArtistAndTitle
     |> Array.groupBy (groupName settings)
-    |> Array.filter (fun (_, tags) -> Array.hasMultiple tags)
+    |> Array.filter (snd >> Array.hasMultiple)
     |> Array.sortBy fst // Group name
-    |> Array.map (fun (_, tags) -> tags |> Array.sortBy (mainArtists String.Empty))
+    |> Array.map (snd >> Array.sortBy (mainArtists String.Empty))
     |> Array.toNonEmptyListOption
 
 let printDuplicates (groupedTracks: LibraryTags array NonEmptyList option) =

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -5,6 +5,7 @@ open Settings
 open Shared
 open Shared.TagLibrary
 open FSharpPlus
+open FSharpPlus.Data
 open CCFSharpUtils.Library
 open System
 open System.IO
@@ -73,16 +74,16 @@ let private groupName (settings: Settings) fileTags =
 
     $"{artist}{title}".ToLowerInvariant()
 
-let findDuplicates settings (tags: LibraryTags array) : LibraryTags array array option =
+let findDuplicates settings (tags: LibraryTags array) : LibraryTags array NonEmptyList option =
     tags
     |> Array.filter hasArtistAndTitle
     |> Array.groupBy (groupName settings)
     |> Array.filter (fun (_, tags) -> Array.hasMultiple tags)
     |> Array.sortBy fst // Group name
     |> Array.map (fun (_, tags) -> tags |> Array.sortBy (mainArtists String.Empty))
-    |> Array.toOption
+    |> Array.toNonEmptyListOption
 
-let printDuplicates (groupedTracks: LibraryTags array array option) =
+let printDuplicates (groupedTracks: LibraryTags array NonEmptyList option) =
     let printfGray = printfColor ConsoleColor.DarkGray
 
     let printGroup index (groupTracks: LibraryTags array) =
@@ -118,4 +119,4 @@ let printDuplicates (groupedTracks: LibraryTags array array option) =
 
     match groupedTracks with
     | None -> printfn "No duplicates found."
-    | Some group -> group |> Array.iteri printGroup
+    | Some group -> group |> NonEmptyList.iteri printGroup

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -14,11 +14,11 @@ let parseToTags json =
     |> parseToTags
     |! TagParseError
 
-let printCount description (tags: MultipleLibraryTags) =
+let printCount description (tags: LibraryTags array) =
     printfn $"%s{description}%s{String.formatInt tags.Length}"
 
 /// Filters out tags containing artists or titles specified in the exclusions in the settings.
-let discardExcluded (settings: Settings) allTags : MultipleLibraryTags =
+let discardExcluded (settings: Settings) allTags : LibraryTags array =
     let isExcluded tags =
         let (|ArtistAndTitle|ArtistOnly|TitleOnly|Invalid|) (excl: Exclusion) =
             match excl.Artist, excl.Title with
@@ -73,7 +73,7 @@ let private groupName (settings: Settings) fileTags =
 
     $"{artist}{title}".ToLowerInvariant()
 
-let findDuplicates settings (tags: MultipleLibraryTags) : MultipleLibraryTags array option =
+let findDuplicates settings (tags: LibraryTags array) : LibraryTags array array option =
     tags
     |> Array.filter hasArtistAndTitle
     |> Array.groupBy (groupName settings)
@@ -82,10 +82,10 @@ let findDuplicates settings (tags: MultipleLibraryTags) : MultipleLibraryTags ar
     |> Array.map (fun (_, tags) -> tags |> Array.sortBy (mainArtists String.Empty))
     |> Array.toOption
 
-let printDuplicates (groupedTracks: MultipleLibraryTags array option) =
+let printDuplicates (groupedTracks: LibraryTags array array option) =
     let printfGray = printfColor ConsoleColor.DarkGray
 
-    let printGroup index (groupTracks: MultipleLibraryTags) =
+    let printGroup index (groupTracks: LibraryTags array) =
         let artistSummary (tags: LibraryTags) : string =
             if Array.isEmpty tags.Artists
             then String.Empty

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -11,9 +11,7 @@ open System
 open System.IO
 
 let parseToTags json =
-    json
-    |> parseToTags
-    |! TagParseError
+    json |> parseToTags |! TagParseError
 
 let printCount description (tags: LibraryTags array) =
     printfn $"%s{description}%s{String.formatInt tags.Length}"

--- a/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
+++ b/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.51" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.52" />
       <PackageReference Include="FSharp.Data" Version="8.1.3" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />

--- a/src/AudioTagTools.GenreExtractor/Exporting.fs
+++ b/src/AudioTagTools.GenreExtractor/Exporting.fs
@@ -18,10 +18,10 @@ let printOldSummary (oldGenres: string array) : unit =
         let count = oldGenres.Length
         printfn "%s %s in the old file." (String.formatInt count) (String.pluralize "entry" "entries" count)
 
-let printTagCount (tags: MultipleLibraryTags) =
+let printTagCount (tags: LibraryTags array) =
     printfn $"Parsed tags for {String.formatInt tags.Length} files from the tag library."
 
-let private allGenres (fileTags: MultipleLibraryTags) : string array =
+let private allGenres (fileTags: LibraryTags array) : string array =
     fileTags
     |> Array.collect _.Genres
 
@@ -37,7 +37,7 @@ let private mostCommon (items: string array) : string =
 
 let private mostCommonGenre = allGenres >> mostCommon
 
-let generateGenreData (separator: string) (allFileTags: MultipleLibraryTags) =
+let generateGenreData (separator: string) (allFileTags: LibraryTags array) =
     allFileTags
     |> Array.groupBy mainArtist
     |> Array.choose (fun (artist, tags) ->

--- a/src/AudioTagTools.GenreExtractor/Exporting.fs
+++ b/src/AudioTagTools.GenreExtractor/Exporting.fs
@@ -32,7 +32,7 @@ let private mostCommon (items: string array) : string =
     | _ ->
         items
         |> Array.groupBy id
-        |> Array.maxBy (fun (_, groupItems) -> Array.length groupItems)
+        |> Array.maxBy (snd >> Array.length)
         |> fst
 
 let private mostCommonGenre = allGenres >> mostCommon

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -32,7 +32,7 @@ let private run args : Result<unit, GenreExtractorError> =
 
         do!
             genreFile
-            |> backUpFile
+            |>  backUpFile
             |>> printfn "Created backup file \"%O\"." // %O formats with ToString().
             |!  FileWriteError
 
@@ -44,5 +44,5 @@ let private run args : Result<unit, GenreExtractorError> =
 
 let start args : Result<string, string> =
     match run args with
-    | Ok () -> Ok "Finished exporting genres successfully!"
+    | Ok ()   -> Ok "Finished exporting genres successfully!"
     | Error e -> Error (message e)

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -38,7 +38,7 @@ let private run args : Result<unit, GenreExtractorError> =
 
         return!
             newGenres
-            |> File.writeLines genreFile.FullName
+            |> File.writeLines' genreFile
             |! FileWriteError
     }
 

--- a/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
+++ b/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
@@ -21,7 +21,7 @@
     <ItemGroup>
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
-      <PackageReference Include="CCFSharpUtils" Version="0.1.51" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.52" />
     </ItemGroup>
 
 </Project>

--- a/src/AudioTagTools.LibraryAnalysis/Library.fs
+++ b/src/AudioTagTools.LibraryAnalysis/Library.fs
@@ -123,5 +123,5 @@ let private run (args: string array) : Result<unit, AnalysisError> =
 
 let start args : Result<string, string> =
     match run args with
-    | Ok () -> Ok "Finished analysis successfully!"
+    | Ok ()   -> Ok "Finished analysis successfully!"
     | Error e -> Error (message e)

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -14,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.1.51" />
+      <PackageReference Include="CCFSharpUtils" Version="0.1.52" />
       <PackageReference Include="FSharp.Data" Version="8.1.3" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -1,6 +1,5 @@
 module Shared.TagLibrary
 
-open FSharpPlus
 open CCFSharpUtils.Library
 open System
 open System.IO
@@ -46,13 +45,10 @@ let blankTags (fileInfo: FileInfo) : LibraryTags =
 
 let parseToTags (json: string) : Result<LibraryTags array, string> =
     try Ok (JsonSerializer.Deserialize<LibraryTags array>(json))
-    with e -> Error e.Message
+    with exn -> Error exn.Message
 
 let parseFileTags (filePath: string) : Result<FileTags option, string> =
-    try
-        FileTags.Create filePath
-        |> Option.ofObj
-        |> Ok
+    try filePath |> FileTags.Create |> Option.ofObj |> Ok
     with exn -> Error exn.Message
 
 let path tags : string =

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -26,8 +26,6 @@ type LibraryTags =
       ImageCount: int
       LastWriteTime: DateTimeOffset }
 
-type MultipleLibraryTags = LibraryTags array
-
 let blankTags (fileInfo: FileInfo) : LibraryTags =
     { FileName = fileInfo.Name
       DirectoryName = fileInfo.DirectoryName
@@ -46,8 +44,8 @@ let blankTags (fileInfo: FileInfo) : LibraryTags =
       ImageCount = 0
       LastWriteTime = DateTimeOffset fileInfo.LastWriteTime }
 
-let parseToTags (json: string) : Result<MultipleLibraryTags, string> =
-    try Ok (JsonSerializer.Deserialize<MultipleLibraryTags>(json))
+let parseToTags (json: string) : Result<LibraryTags array, string> =
+    try Ok (JsonSerializer.Deserialize<LibraryTags array>(json))
     with e -> Error e.Message
 
 let parseFileTags (filePath: string) : Result<FileTags option, string> =


### PR DESCRIPTION
- Removes the `MultipleLibraryTags` type, as it never felt very clear
- Minor code tweaks