### PR TITLE
Reduce primitive obsession; operator updates; etc.

### DIFF
--- a/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
+++ b/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
@@ -16,8 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
-      <PackageReference Include="FSharp.Data" Version="8.1.7" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />

--- a/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
+++ b/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
+++ b/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.1" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
       <PackageReference Include="FSharp.Data" Version="8.1.7" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
+++ b/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
@@ -16,11 +16,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5.1" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />
-      <PackageReference Update="FSharp.Core" Version="10.1.201" />
+      <PackageReference Update="FSharp.Core" Version="10.1.202" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
+++ b/src/AudioTagTools.Cacher/AudioTagTools.Cacher.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -19,7 +19,7 @@ let private run args : Result<unit, CommandError> =
         let _ =
             backUpFile tagLibraryFile
             |- printfn "Backed up previous file to \"%O\"."
-            |! FileWriteError
+            |!! FileWriteError
 
         do!
             newJson

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -4,10 +4,11 @@ open ArgValidation
 open Errors
 open IO
 open Tags
-open Shared.Constants
+open Shared.IO
 open CCFSharpUtils
 open CCFSharpUtils.Operators
 open FSharpPlus
+
 
 let private run args : Result<unit, CommandError> =
     monad' {

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -17,16 +17,15 @@ let private run args : Result<unit, CommandError> =
         let! newJson = fileInfos |> generateJson tagLibraryMap
 
         let _ =
-            tagLibraryFile
-            |> backUpFile
-            |. printfn "Backed up previous file to \"%O\"."
+            backUpFile tagLibraryFile
+            |- printfn "Backed up previous file to \"%O\"."
             |! FileWriteError
 
         do!
             newJson
             |> File.writeText' tagLibraryFile
-            |. fun _ -> printfn $"Wrote new file \"%O{tagLibraryFile}\"."
-            |! FileWriteError
+            |- fun _ -> printfn $"Wrote new file \"%O{tagLibraryFile}\"."
+            |!! FileWriteError
     }
 
 let start args : Result<string, string> =

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -27,7 +27,7 @@ let createTagLibraryMap (libraryFile: FileInfo) : Result<LibraryTagMap, CommandE
         libraryFile
         |>  File.readText'
         >>= (Json >> parseJsonToTags)
-        |!  LibraryTagParseError
+        |!! LibraryTagParseError
         |>> (List.map groupWithPath >> Map.ofList)
     else
         Ok Map.empty
@@ -111,4 +111,4 @@ let generateJson (tagMap: LibraryTagMap) (fileInfos: FileInfo nseq) : Result<str
     |> reportResults
     |> NonEmptySeq.map _.Tags
     |> String.toJson
-    |! JsonSerializationError
+    |!! JsonSerializationError

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -4,6 +4,7 @@ open System
 open IO
 open Errors
 open Shared.TagLibrary
+open Shared.Types
 open CCFSharpUtils
 open CCFSharpUtils.Operators
 open FSharpPlus.Data
@@ -25,7 +26,7 @@ let createTagLibraryMap (libraryFile: FileInfo) : Result<LibraryTagMap, CommandE
     then
         libraryFile
         |>  File.readText'
-        >>= parseJsonToTags
+        >>= (Json >> parseJsonToTags)
         |!  LibraryTagParseError
         |>> (List.map groupWithPath >> Map.ofList)
     else

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -63,7 +63,7 @@ let private prepareTagsToWrite tagLibraryMap (fileInfos: FileInfo nseq)
                 LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
             }
 
-       match parseFileTags fileInfo.FullName with
+       match parseFileTags fileInfo with
        | Ok (Some tags) -> tagsFromFile tags
        | _ -> blankTags fileInfo
 

--- a/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
+++ b/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.1" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
+++ b/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
+++ b/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
@@ -13,11 +13,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5.1" />
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />
-      <PackageReference Update="FSharp.Core" Version="10.1.201" />
+      <PackageReference Update="FSharp.Core" Version="10.1.202" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
+++ b/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
+++ b/src/AudioTagTools.Console/AudioTagTools.Console.fsproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
       <PackageReference Include="CodeConscious.Startwatch" Version="1.0.0" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
+++ b/src/AudioTagTools.DuplicateFinder/ArgValidation.fs
@@ -15,6 +15,6 @@ let validate args : Result<FileInfo * FileInfo, CommandError> =
             and! tagLibFile   = tagLibArg   |> File.toFileInfoV $"Tag library file \"{tagLibArg}\" does not exist."
             return (settingsFile, tagLibFile) }
         |> Validation.toResult
-        |! (NonEmptyList.ofList >> ArgErrors)
+        |!! (NonEmptyList.ofList >> ArgErrors)
     | _ ->
         Error ArgCountError

--- a/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
+++ b/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
+++ b/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.1" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
       <PackageReference Include="FSharp.Data" Version="8.1.7" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
+++ b/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
@@ -17,11 +17,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5.1" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />
-      <PackageReference Update="FSharp.Core" Version="10.1.201" />
+      <PackageReference Update="FSharp.Core" Version="10.1.202" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
+++ b/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
@@ -17,8 +17,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
-      <PackageReference Include="FSharp.Data" Version="8.1.7" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />

--- a/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
+++ b/src/AudioTagTools.DuplicateFinder/AudioTagTools.DuplicateFinder.fsproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.DuplicateFinder/Errors.fs
+++ b/src/AudioTagTools.DuplicateFinder/Errors.fs
@@ -7,7 +7,7 @@ type CommandError =
     | ArgErrors of string nlist
     | FileReadError of string
     | FileWriteError of string
-    | SettingParseError of string
+    | SettingsParseError of string
     | TagParseError of string
     | NoFilesRemainAfterFiltering
 
@@ -16,6 +16,6 @@ let message = function
     | ArgErrors errs -> errs |> String.concatNL
     | FileReadError msg -> $"I/O read failure: {msg}"
     | FileWriteError msg -> $"I/O write failure: {msg}"
-    | SettingParseError msg -> $"Failure parsing settings file: {msg}"
+    | SettingsParseError msg -> $"Failure parsing settings file: {msg}"
     | TagParseError msg -> $"Failure parsing tag library file: {msg}"
     | NoFilesRemainAfterFiltering -> "No files to check remained after filtering."

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -48,5 +48,5 @@ let savePlaylist
         |> NonEmptyList.fold appendFileEntry (SB $"#EXTM3U{String.nl}")
         |> string
         |> File.writeText' file
-        |. fun _ -> printfn $"Created playlist file \"{file}\"."
+        |-- fun _ -> printfn $"Created playlist file \"{file}\"."
         |! FileWriteError

--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -49,4 +49,4 @@ let savePlaylist
         |> string
         |> File.writeText' file
         |-- fun _ -> printfn $"Created playlist file \"{file}\"."
-        |! FileWriteError
+        |!! FileWriteError

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -24,9 +24,9 @@ let private run args : Result<unit, CommandError> =
            tags
            |- printCount "Total file count:    "
            |> discardExcluded settings
-           |. printCount "Filtered file count: "
+           |-- printCount "Filtered file count: "
            |>> findDuplicates settings
-           |. printDuplicates
+           |-- printDuplicates
 
         return!
             duplicates |> savePlaylist settings

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -16,7 +16,7 @@ let private run args : Result<unit, CommandError> =
         let! settingsFile, tagLibFile = validate args
 
         let! settings = settingsFile |> File.readText' |!! FileReadError >>= (Json >> parseToSettings)
-        let! tags = tagLibFile |> File.readText' |!! FileReadError >>= (Json >> parseToTags)
+        let! tags     = tagLibFile   |> File.readText' |!! FileReadError >>= (Json >> parseToTags)
 
         printSummary settings
 

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -5,6 +5,7 @@ open ArgValidation
 open IO
 open Tags
 open Settings
+open Shared.Types
 open CCFSharpUtils
 open CCFSharpUtils.Operators
 open FSharpPlus
@@ -14,8 +15,8 @@ let private run args : Result<unit, CommandError> =
     monad' {
         let! settingsFile, tagLibraryFile = validate args
 
-        let! settings    = settingsFile   |> File.readText' |! FileReadError >>= parseToSettings
-        let! libraryTags = tagLibraryFile |> File.readText' |! FileReadError >>= parseToTags
+        let! settings    = settingsFile   |> File.readText' |! FileReadError >>= (Json >> parseToSettings)
+        let! libraryTags = tagLibraryFile |> File.readText' |! FileReadError >>= (Json >> parseToTags)
 
         printSummary settings
 

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -22,7 +22,7 @@ let private run args : Result<unit, CommandError> =
 
         let! duplicates =
            tags
-           |> tap (printCount "Total file count:    ")
+           |- printCount "Total file count:    "
            |> discardExcluded settings
            |. printCount "Filtered file count: "
            |>> findDuplicates settings

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -13,15 +13,15 @@ open FsToolkit.ErrorHandling.Operator.Result
 
 let private run args : Result<unit, CommandError> =
     monad' {
-        let! settingsFile, tagLibraryFile = validate args
+        let! settingsFile, tagLibFile = validate args
 
-        let! settings    = settingsFile   |> File.readText' |! FileReadError >>= (Json >> parseToSettings)
-        let! libraryTags = tagLibraryFile |> File.readText' |! FileReadError >>= (Json >> parseToTags)
+        let! settings = settingsFile |> File.readText' |! FileReadError >>= (Json >> parseToSettings)
+        let! tags = tagLibFile |> File.readText' |! FileReadError >>= (Json >> parseToTags)
 
         printSummary settings
 
         let! duplicates =
-           libraryTags
+           tags
            |> tap (printCount "Total file count:    ")
            |> discardExcluded settings
            |. printCount "Filtered file count: "

--- a/src/AudioTagTools.DuplicateFinder/Library.fs
+++ b/src/AudioTagTools.DuplicateFinder/Library.fs
@@ -15,8 +15,8 @@ let private run args : Result<unit, CommandError> =
     monad' {
         let! settingsFile, tagLibFile = validate args
 
-        let! settings = settingsFile |> File.readText' |! FileReadError >>= (Json >> parseToSettings)
-        let! tags = tagLibFile |> File.readText' |! FileReadError >>= (Json >> parseToTags)
+        let! settings = settingsFile |> File.readText' |!! FileReadError >>= (Json >> parseToSettings)
+        let! tags = tagLibFile |> File.readText' |!! FileReadError >>= (Json >> parseToTags)
 
         printSummary settings
 

--- a/src/AudioTagTools.DuplicateFinder/Settings.fs
+++ b/src/AudioTagTools.DuplicateFinder/Settings.fs
@@ -42,7 +42,7 @@ type Exclusion = SettingsProvider.Exclusion
 
 let parseToSettings (Json json) : Result<Settings, CommandError> =
     try json |> SettingsProvider.Parse |> Ok
-    with e -> Error (SettingsParseError e.Message)
+    with exn -> Error (SettingsParseError exn.Message)
 
 let printSummary (settings: Settings) =
     printfn "Settings:"

--- a/src/AudioTagTools.DuplicateFinder/Settings.fs
+++ b/src/AudioTagTools.DuplicateFinder/Settings.fs
@@ -40,8 +40,8 @@ type SettingsProvider = JsonProvider<settingsSample>
 type Settings = SettingsProvider.Root
 type Exclusion = SettingsProvider.Exclusion
 
-let parseToSettings (Json jsonText) : Result<Settings, CommandError> =
-    try SettingsProvider.Parse jsonText |> Ok
+let parseToSettings (Json json) : Result<Settings, CommandError> =
+    try json |> SettingsProvider.Parse |> Ok
     with e -> Error (SettingParseError e.Message)
 
 let printSummary (settings: Settings) =

--- a/src/AudioTagTools.DuplicateFinder/Settings.fs
+++ b/src/AudioTagTools.DuplicateFinder/Settings.fs
@@ -42,7 +42,7 @@ type Exclusion = SettingsProvider.Exclusion
 
 let parseToSettings (Json json) : Result<Settings, CommandError> =
     try json |> SettingsProvider.Parse |> Ok
-    with e -> Error (SettingParseError e.Message)
+    with e -> Error (SettingsParseError e.Message)
 
 let printSummary (settings: Settings) =
     printfn "Settings:"

--- a/src/AudioTagTools.DuplicateFinder/Settings.fs
+++ b/src/AudioTagTools.DuplicateFinder/Settings.fs
@@ -1,5 +1,6 @@
 module DuplicateFinder.Settings
 
+open Shared.Types
 open Errors
 open FSharp.Data
 
@@ -39,8 +40,8 @@ type SettingsProvider = JsonProvider<settingsSample>
 type Settings = SettingsProvider.Root
 type Exclusion = SettingsProvider.Exclusion
 
-let parseToSettings (json: string) : Result<Settings, CommandError> =
-    try SettingsProvider.Parse json |> Ok
+let parseToSettings (Json jsonText) : Result<Settings, CommandError> =
+    try SettingsProvider.Parse jsonText |> Ok
     with e -> Error (SettingParseError e.Message)
 
 let printSummary (settings: Settings) =

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -12,7 +12,7 @@ open System
 open System.IO
 
 let parseToTags json =
-    json |> parseJsonToNonEmptyTags |! TagParseError
+    json |> parseJsonToNonEmptyTags |!! TagParseError
 
 let printCount description (tags: LibraryTags nlist) =
     printfn $"%s{description}%s{String.formatInt tags.Length}"

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -5,7 +5,6 @@ open Settings
 open Shared
 open Shared.TagLibrary
 open FSharpPlus
-open FSharpPlus.Control
 open FSharpPlus.Data
 open CCFSharpUtils
 open CCFSharpUtils.Operators

--- a/src/AudioTagTools.GenreExtractor/ArgValidation.fs
+++ b/src/AudioTagTools.GenreExtractor/ArgValidation.fs
@@ -14,6 +14,6 @@ let validate args : Result<(FileInfo * FileInfo), CommandError>=
             let! tagLib = tagLibArg |> File.toFileInfoV $"Tag library file \"{tagLibArg}\" does not exist."
             return (tagLib, FileInfo genreFileArg) }
         |> Validation.toResult
-        |! (NonEmptyList.ofList >> ArgErrors)
+        |!! (NonEmptyList.ofList >> ArgErrors)
     | _ ->
         Error ArgCountError

--- a/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
+++ b/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />

--- a/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
+++ b/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
@@ -16,8 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
-      <PackageReference Include="FSharp.Data" Version="8.1.7" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
     </ItemGroup>

--- a/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
+++ b/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />

--- a/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
+++ b/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
@@ -16,9 +16,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5.1" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
-      <PackageReference Update="FSharp.Core" Version="10.1.201" />
+      <PackageReference Update="FSharp.Core" Version="10.1.202" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
     </ItemGroup>
 

--- a/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
+++ b/src/AudioTagTools.GenreExtractor/AudioTagTools.GenreExtractor.fsproj
@@ -16,7 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.1" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
       <PackageReference Include="FSharp.Data" Version="8.1.7" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />

--- a/src/AudioTagTools.GenreExtractor/IO.fs
+++ b/src/AudioTagTools.GenreExtractor/IO.fs
@@ -9,8 +9,8 @@ open System.IO
 let readGenres (genreFile: FileInfo) : Result<string list, CommandError> =
     if genreFile.Exists then
         genreFile
-        |>  File.readLines'
+        |> File.readLines'
         |>> List.ofArray
-        |!  FileReadError
+        |!! FileReadError
     else
         Ok List.empty

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -5,6 +5,7 @@ open Errors
 open Exporting
 open IO
 open Shared.TagLibrary
+open Shared.Types
 open Shared.Constants
 open CCFSharpUtils
 open CCFSharpUtils.Operators
@@ -15,24 +16,17 @@ let private separator = "＼"
 
 let private run args : Result<unit, CommandError> =
     monad' {
-        let! tagLibraryFile, genreFile = validate args
+        let! tagLibFile, genreFile = validate args
 
         let! oldGenres = genreFile |> readGenres |. printOldSummary
-
-        let! tags =
-            tagLibraryFile
-            |>  File.readText'
-            >>= parseJsonToNonEmptyTags
-            |!  TagParseError
-            |.  printTagCount
-
-        let! newGenres = tags |> generateGenreData separator
+        let! jsonTags = tagLibFile |> File.readText' |>> Json |! FileReadError
+        let! parsedTags = jsonTags |> parseJsonToNonEmptyTags |. printTagCount |! TagParseError
+        let! newGenres = parsedTags |> generateGenreData separator
 
         printChanges oldGenres newGenres
 
         do!
-            genreFile
-            |>  backUpFile
+            backUpFile genreFile
             |>> printfn "Created backup file \"%O\"." // %O formats with ToString().
             |!  FileWriteError
 

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -6,7 +6,7 @@ open Exporting
 open IO
 open Shared.TagLibrary
 open Shared.Types
-open Shared.Constants
+open Shared.IO
 open CCFSharpUtils
 open CCFSharpUtils.Operators
 open FSharpPlus

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -18,9 +18,9 @@ let private run args : Result<unit, CommandError> =
     monad' {
         let! tagLibFile, genreFile = validate args
 
-        let! oldGenres = genreFile |> readGenres |. printOldSummary
+        let! oldGenres = genreFile |> readGenres |-- printOldSummary
         let! jsonTags = tagLibFile |> File.readText' |>> Json |! FileReadError
-        let! parsedTags = jsonTags |> parseJsonToNonEmptyTags |. printTagCount |! TagParseError
+        let! parsedTags = jsonTags |> parseJsonToNonEmptyTags |-- printTagCount |! TagParseError
         let! newGenres = parsedTags |> generateGenreData separator
 
         printChanges oldGenres newGenres

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -19,9 +19,9 @@ let private run args : Result<unit, CommandError> =
         let! tagLibFile, genreFile = validate args
 
         let! oldGenres = genreFile |> readGenres |-- printOldSummary
-        let! jsonTags = tagLibFile |> File.readText' |>> Json |!! FileReadError
-        let! parsedTags = jsonTags |> parseJsonToNonEmptyTags |-- printTagCount |!! TagParseError
-        let! newGenres = parsedTags |> generateGenreData separator
+        let! tagJson = tagLibFile |> File.readText' |>> Json |!! FileReadError
+        let! tags = tagJson |> parseJsonToNonEmptyTags |-- printTagCount |!! TagParseError
+        let! newGenres = tags |> generateGenreData separator
 
         printChanges oldGenres newGenres
 

--- a/src/AudioTagTools.GenreExtractor/Library.fs
+++ b/src/AudioTagTools.GenreExtractor/Library.fs
@@ -19,8 +19,8 @@ let private run args : Result<unit, CommandError> =
         let! tagLibFile, genreFile = validate args
 
         let! oldGenres = genreFile |> readGenres |-- printOldSummary
-        let! jsonTags = tagLibFile |> File.readText' |>> Json |! FileReadError
-        let! parsedTags = jsonTags |> parseJsonToNonEmptyTags |-- printTagCount |! TagParseError
+        let! jsonTags = tagLibFile |> File.readText' |>> Json |!! FileReadError
+        let! parsedTags = jsonTags |> parseJsonToNonEmptyTags |-- printTagCount |!! TagParseError
         let! newGenres = parsedTags |> generateGenreData separator
 
         printChanges oldGenres newGenres
@@ -28,12 +28,12 @@ let private run args : Result<unit, CommandError> =
         do!
             backUpFile genreFile
             |>> printfn "Created backup file \"%O\"." // %O formats with ToString().
-            |!  FileWriteError
+            |!! FileWriteError
 
         return!
             newGenres
             |> File.writeLines' genreFile
-            |! FileWriteError
+            |!! FileWriteError
     }
 
 let start args : Result<string, string> =

--- a/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
+++ b/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
@@ -19,9 +19,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Update="FSharp.Core" Version="10.1.201" />
+      <PackageReference Update="FSharp.Core" Version="10.1.202" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
-      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5.1" />
     </ItemGroup>
 
 </Project>

--- a/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
+++ b/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
@@ -21,7 +21,7 @@
     <ItemGroup>
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
-      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
     </ItemGroup>
 
 </Project>

--- a/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
+++ b/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
@@ -21,7 +21,7 @@
     <ItemGroup>
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
-      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
     </ItemGroup>
 
 </Project>

--- a/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
+++ b/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
@@ -21,7 +21,7 @@
     <ItemGroup>
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
-      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
     </ItemGroup>
 
 </Project>

--- a/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
+++ b/src/AudioTagTools.LibraryAnalysis/AudioTagTools.LibraryAnalysis.fsproj
@@ -21,7 +21,7 @@
     <ItemGroup>
       <PackageReference Update="FSharp.Core" Version="10.1.201" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
-      <PackageReference Include="CCFSharpUtils" Version="0.3.1" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
     </ItemGroup>
 
 </Project>

--- a/src/AudioTagTools.LibraryAnalysis/Library.fs
+++ b/src/AudioTagTools.LibraryAnalysis/Library.fs
@@ -18,8 +18,8 @@ type QualityData =
 let private run args : Result<unit, CommandError> =
     monad' {
         let! tagLibraryFile = validate args
-        let! jsonTags = tagLibraryFile |> File.readText' |>> Json |! FileReadError
-        let! parsedTags = jsonTags |> parseJsonToTags |! TagParseError
+        let! jsonTags = tagLibraryFile |> File.readText' |>> Json |!! FileReadError
+        let! parsedTags = jsonTags |> parseJsonToTags |!! TagParseError
 
         printTable {
             Title = Some "General Data"

--- a/src/AudioTagTools.LibraryAnalysis/Library.fs
+++ b/src/AudioTagTools.LibraryAnalysis/Library.fs
@@ -10,11 +10,6 @@ open CCFSharpUtils.Operators
 open Spectre.Console
 open FSharpPlus
 
-type QualityData =
-    { BitRate: int
-      Extension: string
-      SampleRate: int }
-
 let private run args : Result<unit, CommandError> =
     monad' {
         let! tagLibraryFile = validate args

--- a/src/AudioTagTools.LibraryAnalysis/Library.fs
+++ b/src/AudioTagTools.LibraryAnalysis/Library.fs
@@ -9,7 +9,6 @@ open CCFSharpUtils
 open CCFSharpUtils.Operators
 open Spectre.Console
 open FSharpPlus
-open FsToolkit.ErrorHandling.Operator.Result
 
 type QualityData =
     { BitRate: int
@@ -19,16 +18,17 @@ type QualityData =
 let private run args : Result<unit, CommandError> =
     monad' {
         let! tagLibraryFile = validate args
-        let! tags = tagLibraryFile |> File.readText' >>= (Json >> parseJsonToTags) |! TagParseError
+        let! jsonTags = tagLibraryFile |> File.readText' |>> Json |! FileReadError
+        let! parsedTags = jsonTags |> parseJsonToTags |! TagParseError
 
         printTable {
             Title = Some "General Data"
             Headers = None
             Rows =
-                [ [ "Track count"; String.formatInt tags.Length ]
-                  [ "Unique artists"; String.formatInt <| uniqueArtistCount tags ]
-                  [ "Average file size"; String.formatBytes <| averageFileSize tags  ]
-                  [ "Album art percentage"; $"%s{albumArtPercentage tags}" ] ]
+                [ [ "Track count"; String.formatInt parsedTags.Length ]
+                  [ "Unique artists"; String.formatInt <| uniqueArtistCount parsedTags ]
+                  [ "Average file size"; String.formatBytes <| averageFileSize parsedTags  ]
+                  [ "Album art percentage"; $"%s{albumArtPercentage parsedTags}" ] ]
             ColumnAlignments = [Justify.Left; Justify.Right]
             ShowRowSeparators = false
         }
@@ -36,7 +36,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Artists"
             Headers = Some ["Artist"; "Count"; "Ratio"]
-            Rows = topArtists 30 tags
+            Rows = topArtists 30 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -44,7 +44,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Album Names"
             Headers = Some ["Album"; "Count"; "Ratio"]
-            Rows = topAlbums 30 tags
+            Rows = topAlbums 30 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -52,7 +52,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Titles"
             Headers = Some ["Title"; "Count"]
-            Rows = topTitles 30 tags
+            Rows = topTitles 30 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Right]
             ShowRowSeparators = false
         }
@@ -60,7 +60,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Genres"
             Headers = Some ["Genre"; "Count"; "Ratio"]
-            Rows = topGenres 30 tags
+            Rows = topGenres 30 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -68,7 +68,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Artists With The Most Genres"
             Headers = Some ["Artist"; "Count"; "Genres"]
-            Rows = artistsWithMostGenres 20 tags
+            Rows = artistsWithMostGenres 20 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Left]
             ShowRowSeparators = false
         }
@@ -76,7 +76,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Largest Files"
             Headers = Some ["File Size"; "Artist & Title"]
-            Rows = largestFiles 20 tags |> List.map List.rev
+            Rows = largestFiles 20 parsedTags |> List.map List.rev
             ColumnAlignments = [Justify.Right; Justify.Left]
             ShowRowSeparators = false
         }
@@ -84,7 +84,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Formats"
             Headers = Some ["Extension"; "Count"]
-            Rows = topFormats 10 tags
+            Rows = topFormats 10 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Right]
             ShowRowSeparators = false
         }
@@ -92,7 +92,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Bitrates"
             Headers = Some ["Bitrate"; "Count"]
-            Rows = topBitRates 10 tags
+            Rows = topBitRates 10 parsedTags
             ColumnAlignments = [Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -100,7 +100,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Sample Rates"
             Headers = Some ["Sample Rate"; "Count"]
-            Rows = topSampleRates 10 tags
+            Rows = topSampleRates 10 parsedTags
             ColumnAlignments = [Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -108,7 +108,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Quality Combinations"
             Headers = Some ["Format"; "Bit Rate"; "Sample Rate"; "Count"]
-            Rows = topQualityData 10 tags
+            Rows = topQualityData 10 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -116,7 +116,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Longest File Names"
             Headers = Some ["Artist & Title"; "Filename"; "Length"]
-            Rows = longestFileNames 5 tags
+            Rows = longestFileNames 5 parsedTags
             ColumnAlignments = [Justify.Left; Justify.Left; Justify.Center]
             ShowRowSeparators = true
         }

--- a/src/AudioTagTools.LibraryAnalysis/Library.fs
+++ b/src/AudioTagTools.LibraryAnalysis/Library.fs
@@ -19,7 +19,7 @@ type QualityData =
 let private run args : Result<unit, CommandError> =
     monad' {
         let! tagLibraryFile = validate args
-        let! tags = tagLibraryFile |> File.readText' >>= parseJsonToTags |! TagParseError
+        let! tags = tagLibraryFile |> File.readText' >>= (Json >> parseJsonToTags) |! TagParseError
 
         printTable {
             Title = Some "General Data"

--- a/src/AudioTagTools.LibraryAnalysis/Library.fs
+++ b/src/AudioTagTools.LibraryAnalysis/Library.fs
@@ -18,17 +18,17 @@ type QualityData =
 let private run args : Result<unit, CommandError> =
     monad' {
         let! tagLibraryFile = validate args
-        let! jsonTags = tagLibraryFile |> File.readText' |>> Json |!! FileReadError
-        let! parsedTags = jsonTags |> parseJsonToTags |!! TagParseError
+        let! tagJson = tagLibraryFile |> File.readText' |>> Json |!! FileReadError
+        let! tags = tagJson |> parseJsonToTags |!! TagParseError
 
         printTable {
             Title = Some "General Data"
             Headers = None
             Rows =
-                [ [ "Track count"; String.formatInt parsedTags.Length ]
-                  [ "Unique artists"; String.formatInt <| uniqueArtistCount parsedTags ]
-                  [ "Average file size"; String.formatBytes <| averageFileSize parsedTags  ]
-                  [ "Album art percentage"; $"%s{albumArtPercentage parsedTags}" ] ]
+                [ [ "Track count"; String.formatInt tags.Length ]
+                  [ "Unique artists"; String.formatInt <| uniqueArtistCount tags ]
+                  [ "Average file size"; String.formatBytes <| averageFileSize tags  ]
+                  [ "Album art percentage"; $"%s{albumArtPercentage tags}" ] ]
             ColumnAlignments = [Justify.Left; Justify.Right]
             ShowRowSeparators = false
         }
@@ -36,7 +36,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Artists"
             Headers = Some ["Artist"; "Count"; "Ratio"]
-            Rows = topArtists 30 parsedTags
+            Rows = topArtists 30 tags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -44,7 +44,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Album Names"
             Headers = Some ["Album"; "Count"; "Ratio"]
-            Rows = topAlbums 30 parsedTags
+            Rows = topAlbums 30 tags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -52,7 +52,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Titles"
             Headers = Some ["Title"; "Count"]
-            Rows = topTitles 30 parsedTags
+            Rows = topTitles 30 tags
             ColumnAlignments = [Justify.Left; Justify.Right]
             ShowRowSeparators = false
         }
@@ -60,7 +60,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Genres"
             Headers = Some ["Genre"; "Count"; "Ratio"]
-            Rows = topGenres 30 parsedTags
+            Rows = topGenres 30 tags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -68,7 +68,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Artists With The Most Genres"
             Headers = Some ["Artist"; "Count"; "Genres"]
-            Rows = artistsWithMostGenres 20 parsedTags
+            Rows = artistsWithMostGenres 20 tags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Left]
             ShowRowSeparators = false
         }
@@ -76,7 +76,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Largest Files"
             Headers = Some ["File Size"; "Artist & Title"]
-            Rows = largestFiles 20 parsedTags |> List.map List.rev
+            Rows = largestFiles 20 tags |> List.map List.rev
             ColumnAlignments = [Justify.Right; Justify.Left]
             ShowRowSeparators = false
         }
@@ -84,7 +84,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Formats"
             Headers = Some ["Extension"; "Count"]
-            Rows = topFormats 10 parsedTags
+            Rows = topFormats 10 tags
             ColumnAlignments = [Justify.Left; Justify.Right]
             ShowRowSeparators = false
         }
@@ -92,7 +92,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Bitrates"
             Headers = Some ["Bitrate"; "Count"]
-            Rows = topBitRates 10 parsedTags
+            Rows = topBitRates 10 tags
             ColumnAlignments = [Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -100,7 +100,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Sample Rates"
             Headers = Some ["Sample Rate"; "Count"]
-            Rows = topSampleRates 10 parsedTags
+            Rows = topSampleRates 10 tags
             ColumnAlignments = [Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -108,7 +108,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Top Quality Combinations"
             Headers = Some ["Format"; "Bit Rate"; "Sample Rate"; "Count"]
-            Rows = topQualityData 10 parsedTags
+            Rows = topQualityData 10 tags
             ColumnAlignments = [Justify.Left; Justify.Right; Justify.Right; Justify.Right]
             ShowRowSeparators = false
         }
@@ -116,7 +116,7 @@ let private run args : Result<unit, CommandError> =
         printTable {
             Title = Some "Longest File Names"
             Headers = Some ["Artist & Title"; "Filename"; "Length"]
-            Rows = longestFileNames 5 parsedTags
+            Rows = longestFileNames 5 tags
             ColumnAlignments = [Justify.Left; Justify.Left; Justify.Center]
             ShowRowSeparators = true
         }

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <Compile Include="Constants.fs" />
+        <Compile Include="Types.fs" />
         <Compile Include="TagLibrary.fs" />
         <Compile Include="Printing.fs" />
     </ItemGroup>

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -15,11 +15,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.5" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.5.1" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />
-      <PackageReference Update="FSharp.Core" Version="10.1.201" />
+      <PackageReference Update="FSharp.Core" Version="10.1.202" />
       <PackageReference Include="Spectre.Console" Version="0.55.0" />
       <PackageReference Include="TagLibSharp" Version="2.3.0" />
     </ItemGroup>

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -15,8 +15,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
-      <PackageReference Include="FSharp.Data" Version="8.1.7" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />
       <PackageReference Update="FSharp.Core" Version="10.1.201" />

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -12,6 +12,7 @@
         <Compile Include="Types.fs" />
         <Compile Include="TagLibrary.fs" />
         <Compile Include="Printing.fs" />
+        <Compile Include="IO.fs" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.1" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.2" />
       <PackageReference Include="FSharp.Data" Version="8.1.7" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
+++ b/src/AudioTagTools.Shared/AudioTagTools.Shared.fsproj
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CCFSharpUtils" Version="0.3.3" />
+      <PackageReference Include="CCFSharpUtils" Version="0.3.4" />
       <PackageReference Include="FSharp.Data" Version="8.1.8" />
       <PackageReference Include="FSharpPlus" Version="1.9.1" />
       <PackageReference Include="FsToolkit.ErrorHandling" Version="5.2.0" />

--- a/src/AudioTagTools.Shared/Constants.fs
+++ b/src/AudioTagTools.Shared/Constants.fs
@@ -1,10 +1,4 @@
 [<AutoOpen>]
 module Shared.Constants
 
-open CCFSharpUtils
-open System.IO
-
 let timeStampFormat = "yyyyMMdd_HHmmss"
-
-let backUpFile : FileInfo -> Result<FileInfo,string> =
-    File.backUpWithTimestamp timeStampFormat

--- a/src/AudioTagTools.Shared/IO.fs
+++ b/src/AudioTagTools.Shared/IO.fs
@@ -1,0 +1,7 @@
+module Shared.IO
+
+open CCFSharpUtils
+open System.IO
+
+let backUpFile : FileInfo -> Result<FileInfo,string> =
+    File.backUpWithTimestamp timeStampFormat

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -54,8 +54,8 @@ let parseJsonToNonEmptyTags json : Result<LibraryTags nlist, string> =
     |> parseJsonToTags
     >>= List.toNonEmptyListResult "No tags were found to parse."
 
-let parseFileTags (filePath: string) : Result<FileTags option, string> =
-    try filePath |> FileTags.Create |> Option.ofObj |> Ok
+let parseFileTags (f: FileInfo) : Result<FileTags option, string> =
+    try f.FullName |> FileTags.Create |> Option.ofObj |> Ok
     with exn -> Error exn.Message
 
 let path tags : string =

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -1,5 +1,6 @@
 module Shared.TagLibrary
 
+open Shared.Types
 open CCFSharpUtils
 open System
 open System.IO
@@ -44,11 +45,11 @@ let blankTags (fileInfo: FileInfo) : LibraryTags =
       ImageCount = 0
       LastWriteTime = DateTimeOffset fileInfo.LastWriteTime }
 
-let parseJsonToTags (json: string) : Result<LibraryTags list, string> =
-    try Ok (JsonSerializer.Deserialize<LibraryTags list> json)
+let parseJsonToTags (Json jsonText) : Result<LibraryTags list, string> =
+    try Ok (JsonSerializer.Deserialize<LibraryTags list> jsonText)
     with exn -> Error exn.Message
 
-let parseJsonToNonEmptyTags (json: string) : Result<LibraryTags nlist, string> =
+let parseJsonToNonEmptyTags json : Result<LibraryTags nlist, string> =
     json
     |> parseJsonToTags
     >>= List.toNonEmptyListResult "No tags were found to parse."

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -71,32 +71,32 @@ let ignorableAlbumArtists =
       "Multiple Artists"
       "\u003Cunknown\u003E" ] // U+003C == less-than sign; \u003E == greater-than sign
 
-let allDistinctArtists (tags: LibraryTags) : string list =
+let allDistinctArtists tags : string list =
     Array.concat [ tags.Artists; tags.AlbumArtists ]
     |> Array.distinct
     |> List.ofArray
 
-let firstDistinctArtist (tags: LibraryTags) : string =
+let firstDistinctArtist tags : string =
     tags |> allDistinctArtists |> List.head
 
-let mainArtists (separator: string) (track: LibraryTags) : string =
+let mainArtists separator tags : string =
     let hasNoIgnoredAlbumArtists artist =
         ignorableAlbumArtists
         |> List.exists _.Equals(artist, StringComparison.InvariantCultureIgnoreCase)
         |> not
 
-    match track with
+    match tags with
     | t when Array.isNotEmpty t.AlbumArtists && hasNoIgnoredAlbumArtists t.AlbumArtists[0] ->
         t.AlbumArtists
     | t ->
         t.Artists
     |> String.concat separator
 
-let hasAnyArtist (tags: LibraryTags) : bool =
+let hasAnyArtist tags : bool =
     Array.anyNotEmpty [| tags.Artists; tags.AlbumArtists |]
 
-let hasTitle (tags: LibraryTags) : bool =
+let hasTitle tags : bool =
     String.hasText tags.Title
 
-let hasArtistAndTitle (track: LibraryTags) : bool =
-    hasAnyArtist track && hasTitle track
+let hasArtistAndTitle tags : bool =
+    hasAnyArtist tags && hasTitle tags

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -45,8 +45,8 @@ let blankTags (fileInfo: FileInfo) : LibraryTags =
       ImageCount = 0
       LastWriteTime = DateTimeOffset fileInfo.LastWriteTime }
 
-let parseJsonToTags (Json jsonText) : Result<LibraryTags list, string> =
-    try Ok (JsonSerializer.Deserialize<LibraryTags list> jsonText)
+let parseJsonToTags (Json json) : Result<LibraryTags list, string> =
+    try Ok (JsonSerializer.Deserialize<LibraryTags list> json)
     with exn -> Error exn.Message
 
 let parseJsonToNonEmptyTags json : Result<LibraryTags nlist, string> =

--- a/src/AudioTagTools.Shared/Types.fs
+++ b/src/AudioTagTools.Shared/Types.fs
@@ -1,0 +1,4 @@
+[<AutoOpen>]
+module Shared.Types
+
+type Json = Json of string


### PR DESCRIPTION
- Reduce some primitive obsession
  - This came to mind when I briefly experienced a bug by swapping two strings I sent to a function. It helped me realize that should be relying on types more to help [make illegal states unrepresentable](https://fsharpforfunandprofit.com/posts/designing-with-types-making-illegal-states-unrepresentable/) in the first place.
- Better and updated operator use