### PR TITLE
Convert exclusions for finding duplicates from text to regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This small command line application performs four tasks:
 1. Cache metadata tags from audio files into a "library file"
-2. Report likely duplicate files based on their tags
+2. Report likely duplicate files based on their tags and personalized settings
 3. Export a list of artists with their most common genres
-4. Analyze library files and display various statistics
+4. Analyze library files to display various statistics
 
-I originally created this tool to practice with F# [JSON type providers](https://fsprojects.github.io/FSharp.Data/library/JsonProvider.html), but it resolves a couple of small pain points for me as well.
+I originally created this tool to practice with [F#](https://fsharp.org/) [JSON type providers](https://fsprojects.github.io/FSharp.Data/library/JsonProvider.html), but I've kept working on it as it resolves a couple of small pain points for me as well.
 
 
 # Requirements
@@ -77,7 +77,18 @@ The file will be in this JSON format:
 
 First, you must already have a tag library file containing your cached tag data. Check the section above if you don't have one yet.
 
-Second, you must have a settings file containing exceptions—i.e., artists, track titles, and strings that you wish to exclude from the search. Actual entries are optional, but the file must be exist in the specified format. I have provided a sample you can use below.
+Second, you must have a settings file containing the following:
+
+1. Paths
+   a. The directory in which to save the playlist of duplicates
+   b. The directory path substring to remove from the file paths, if any, to; otherwise, an empty string
+   c. The directory path substring, if any, that should be prepended onto file paths; otherwise, an empty string
+2. Exclusion patterns: regex patterns to match against the `title` and/or `artist` field for track that you wish not to be include
+3. Equivalent artists: Artists that should be considered identical — particularly useful for artists that release under multiple names
+4. Artist replacement regex patterns to be used to remove matching substrings during comparison
+5. Title replacement regex patterns to be used to remove matching substrings during comparison
+
+I have provided a sample you can use below.
 
 <details>
   <summary>Click to expand the sample and notes...</summary>
@@ -102,7 +113,7 @@ Second, you must have a settings file containing exceptions—i.e., artists, tra
     }
   ],
   "equivalentArtists": [
-      ["artistName", "equivalentArtistName"]
+      ["artistOldName", "artistNewName"]
   ],
   "artistReplacementPatterns": [
     " ",

--- a/README.md
+++ b/README.md
@@ -80,18 +80,26 @@ First, you must already have a tag library file containing your cached tag data.
 Second, you must have a settings file containing the following:
 
 1. Paths
-   a. The directory in which to save the playlist of duplicates
-   b. The directory path substring to remove from the file paths, if any, to; otherwise, an empty string
-   c. The directory path substring, if any, that should be prepended onto file paths; otherwise, an empty string
-2. Exclusion patterns: regex patterns to match against the `title` and/or `artist` field for track that you wish not to be include
-3. Equivalent artists: Artists that should be considered identical — particularly useful for artists that release under multiple names
-4. Artist replacement regex patterns to be used to remove matching substrings during comparison
-5. Title replacement regex patterns to be used to remove matching substrings during comparison
-
-I have provided a sample you can use below.
+   1. The directory in which to save the playlist of duplicates.
+   2. The directory path substring to remove from the file paths, if any, within the playlist of duplicates.
+   3. The directory path substring to prepend to file paths, if any, within the playlist of duplicates.
+   - The final two items function as a pair, allowing you to modify the paths of your files for when your main audio directory's location differs across devices.
+2. Exclusion patterns
+   - Regular expressions to identify tracks, by artist name and/or title, that you wish to ignore during comparison. These might be tracks with identical artists and track names that you know are actually disparate tracks. (A rare but mildly annoying occurrence.)
+3. Equivalent artist names
+   - Artists that should be considered identical during comparison. These are _not_ regular expressions.
+   - Particularly useful for artists that release under multiple names or both in and without bands.
+   - Example: `["Bon Jovi", "Jon Bon Jovi"]`
+4. Artist replacement regular expressions
+   - Removes matching substrings from artist names.
+   - Replacements are in memory for comparison purposes only. No file updates are made.
+   - Example: `["The "]`, which would ensure "The Four Tops" and "Four Tops" are considered identically.
+5. Title replacement regular expressions to be used to remove substrings for comparison
+   - Removes matching substrings from titles.
+   - Replacements are in memory for comparison purposes only. No file updates are made.
 
 <details>
-  <summary>Click to expand the sample and notes...</summary>
+  <summary>Click to expand a sample settings file.</summary>
 
 ```json
 {
@@ -102,8 +110,8 @@ I have provided a sample you can use below.
   },
   "exclusionPatterns": [
     {
-      "artist": "SAMPLE_ARTIST_NAME",
-      "title": "SAMPLE_TRACK_NAME.*"
+      "artist": "EXACT_ARTIST_NAME",
+      "title": "TRACK_NAME_REGEX_PATTERN.*"
     },
     {
       "artist": "SAMPLE_ARTIST_NAME"
@@ -113,28 +121,27 @@ I have provided a sample you can use below.
     }
   ],
   "equivalentArtists": [
-      ["artistOldName", "artistNewName"]
+      ["artistOldName", "artistNewName"],
+      ["artistName", "bandThatArtistIsIn"],
   ],
   "artistReplacementPatterns": [
-    " ",
-    "　",
-    "The ",
+    "The\\s",
     "ザ・"
   ],
   "titleReplacementPatterns": [
-        "−",
-		    "—",
-        "~",
-        "|",
-        "｜",
-        "～",
-        "=",
-        "＝",
-        "\\+",
-        "＋",
-        "✖",
-        "❌",
-        "feat(uring)?\\.?\\s?.+"
+    "feat(uring)?\\.?\\s?.+",
+    "−",
+    "—",
+    "~",
+    "～",
+    "|",
+    "｜",
+    "=",
+    "＝",
+    "\\+",
+    "＋",
+    "✖",
+    "❌",
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -89,16 +89,16 @@ Second, you must have a settings file containing exceptions—i.e., artists, tra
     "pathSearchFor": "/Users/me/Documents/Media/",
     "pathReplaceWith": ""
   },
-  "exclusions": [
+  "exclusionPatterns": [
     {
       "artist": "SAMPLE_ARTIST_NAME",
-      "title": "SAMPLE_TRACK_NAME"
+      "title": "SAMPLE_TRACK_NAME.*"
     },
     {
       "artist": "SAMPLE_ARTIST_NAME"
     },
     {
-      "title": "SAMPLE_TRACK_NAME"
+      "title": "SAMPLE_TRACK_NAME.*"
     }
   ],
   "equivalentArtists": [
@@ -142,7 +142,7 @@ To start, use the `find-duplicates` command like this:
 dotnet run -- find-duplicates ~/Documents/Audio/findDupeSettings.json ~/Documents/Audio/tagLibrary.json
 ```
 
-If any potential duplicates are found, they will be listed, grouped by artist. If you see false positives (i.e., tracks that were detected as duplicates, but are actually not), you can add entries to the exclusions in your settings to ignore them in the future.
+If any potential duplicates are found, they will be listed, grouped by artist. If you see false positives (i.e., tracks that were detected as duplicates, but are actually not), you can add entries to the exclusion patterns in your settings to ignore them in the future.
 
 
 ## 3. Exporting artist genres

--- a/README.md
+++ b/README.md
@@ -81,21 +81,21 @@ Second, you must have a settings file containing the following:
 
 1. Paths
    1. The directory in which to save the playlist of duplicates.
-   2. The directory path substring to remove from the file paths, if any, within the playlist of duplicates.
-   3. The directory path substring to prepend to file paths, if any, within the playlist of duplicates.
-   - The final two items function as a pair, allowing you to modify the paths of your files for when your main audio directory's location differs across devices.
-2. Exclusion patterns
+   2. The directory path substring to _remove_ from each file path within the playlist file for duplicates. Leave blank if unneeded.
+   3. The directory path substring to _prepend_ to each file path within the playlist file for duplicates. Leave blank if unneeded.
+   - Note: The final two items function as a pair, allowing you to modify the paths of your files for when your main audio directory's location differs across devices.
+2. Exclusions
    - Regular expressions to identify tracks, by artist name and/or title, that you wish to ignore during comparison. These might be tracks with identical artists and track names that you know are actually disparate tracks. (A rare but mildly annoying occurrence.)
 3. Equivalent artist names
    - Artists that should be considered identical during comparison. These are _not_ regular expressions.
    - Particularly useful for artists that release under multiple names or both in and without bands.
    - Example: `["Bon Jovi", "Jon Bon Jovi"]`
-4. Artist replacement regular expressions
-   - Removes matching substrings from artist names.
+4. Artist replacements
+   - Regular expressions to remove matching substrings from artist names. Case-insensitive.
    - Replacements are in memory for comparison purposes only. No file updates are made.
    - Example: `["The "]`, which would ensure "The Four Tops" and "Four Tops" are considered identically.
-5. Title replacement regular expressions to be used to remove substrings for comparison
-   - Removes matching substrings from titles.
+5. Title replacements
+   - Regular expressions to remove matching substrings from titles. Case-insensitive.
    - Replacements are in memory for comparison purposes only. No file updates are made.
 
 <details>
@@ -145,12 +145,6 @@ Second, you must have a settings file containing the following:
   ]
 }
 ```
-
-Notes:
-
-1. Use `pathSearchFor` and `pathReplaceWith` if you wish to modify the base path of your media files in the playlist file—for example, if you wish the load the playlist on a different device where the files reside under a different base path. Otherwise, they may be left blank.
-
-2. Use `equivalentArtists` to register lists of artists that should be considered identical for the purposes of duplicate-checking. Results will be reported using the first artist in each group.
 
 </details>
 

--- a/src/AudioTagTools.DuplicateFinder/Settings.fs
+++ b/src/AudioTagTools.DuplicateFinder/Settings.fs
@@ -12,7 +12,7 @@ let settingsSample = """
         "searchPath": "path",
         "replacePath": "path"
     },
-    "exclusions": [
+    "exclusionPatterns": [
         {
             "artist": "artist"
         },
@@ -38,7 +38,7 @@ let settingsSample = """
 
 type SettingsProvider = JsonProvider<settingsSample>
 type Settings = SettingsProvider.Root
-type Exclusion = SettingsProvider.Exclusion
+type ExclusionPattern = SettingsProvider.ExclusionPattern
 
 let parseToSettings (Json json) : Result<Settings, CommandError> =
     try json |> SettingsProvider.Parse |> Ok
@@ -46,6 +46,6 @@ let parseToSettings (Json json) : Result<Settings, CommandError> =
 
 let printSummary (settings: Settings) =
     printfn "Settings:"
-    printfn $"  Exclusions:                  %d{settings.Exclusions.Length}"
+    printfn $"  Exclusion Patterns:          %d{settings.ExclusionPatterns.Length}"
     printfn $"  Artist Replacement Patterns: %d{settings.ArtistReplacementPatterns.Length}"
     printfn $"  Title Replacement Patterns:  %d{settings.TitleReplacementPatterns.Length}"

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -20,14 +20,14 @@ let parseToTags json =
 let printCount description (tags: LibraryTags nlist) =
     printfn $"%s{description}%s{String.formatInt tags.Length}"
 
-/// Filters out tags containing artists or titles specified in the exclusions.
+/// Filters out tags containing artists or titles specified in the exclusionPatterns.
 let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
     : Result<LibraryTags nlist, CommandError> =
 
     let matchOptions = RegexOptions.IgnoreCase
 
     let isExcluded tags =
-        let (|ArtistAndTitle|ArtistOnly|TitleOnly|Invalid|) (excl: Exclusion) =
+        let (|ArtistAndTitle|ArtistOnly|TitleOnly|Invalid|) (excl: ExclusionPattern) =
             match excl.Artist, excl.Title with
             | Some a, Some t -> ArtistAndTitle (a, t)
             | Some a, None   -> ArtistOnly a
@@ -47,7 +47,7 @@ let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
             | TitleOnly t -> titleStartsWith t
             | Invalid -> false
 
-        settings.Exclusions |> Array.exists checkIfExcluded
+        settings.ExclusionPatterns |> Array.exists checkIfExcluded
 
     allTags
     |> NonEmptyList.tryFilter (not << isExcluded)

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -20,15 +20,15 @@ let parseToTags json =
 let printCount description (tags: LibraryTags nlist) =
     printfn $"%s{description}%s{String.formatInt tags.Length}"
 
-/// Filters out tags containing artists or titles specified in the exclusionPatterns.
+/// Filters out tags containing artists or titles specified in the exclusion patterns.
 let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
     : Result<LibraryTags nlist, CommandError> =
 
     let matchOptions = RegexOptions.IgnoreCase
 
     let isExcluded tags =
-        let (|ArtistAndTitle|ArtistOnly|TitleOnly|Invalid|) (excl: ExclusionPattern) =
-            match excl.Artist, excl.Title with
+        let (|ArtistAndTitle|ArtistOnly|TitleOnly|Invalid|) (pattern: ExclusionPattern) =
+            match pattern.Artist, pattern.Title with
             | Some a, Some t -> ArtistAndTitle (a, t)
             | Some a, None   -> ArtistOnly a
             | None,   Some t -> TitleOnly t

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -62,7 +62,6 @@ let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
 let private sanitizedTrackGroupingName (settings: Settings) fileTags =
     let scrubText patterns =
         patterns
-        |> Array.append (String.whiteSpaceStrs |> Array.ofList)
         |> Rgx.scrubMatches
         >> String.stripPunctuation
         >> String.stripDiacritics

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -21,9 +21,7 @@ let printCount description (tags: LibraryTags nlist) =
     printfn $"%s{description}%s{String.formatInt tags.Length}"
 
 /// Filters out tags containing artists or titles specified in the exclusion patterns.
-let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
-    : Result<LibraryTags nlist, CommandError> =
-
+let discardExcluded (settings: Settings) (tagList: LibraryTags nlist) : Result<LibraryTags nlist, CommandError> =
     let matchOptions = RegexOptions.IgnoreCase
 
     let isExcluded tags =
@@ -49,7 +47,7 @@ let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
 
         settings.ExclusionPatterns |> Array.exists checkIfExcluded
 
-    allTags
+    tagList
     |> NonEmptyList.tryFilter (not << isExcluded)
     |> Option.toResultWith NoFilesRemainAfterFiltering
 

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -94,7 +94,7 @@ let findDuplicates settings tags : DuplicateTags option =
         return
             groupedDupes
             |> sortBy fst
-            |> NonEmptyList.map (snd >> sortBy (mainArtists String.Empty))
+            |> NonEmptyList.map (snd >> sortBy _.Title.Length)
     }
 
 let printDuplicates (groupedTracks: DuplicateTags option) : unit =

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -61,8 +61,8 @@ let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
 /// The string is intended to be used solely for track grouping.
 let private sanitizedTrackGroupingName (settings: Settings) fileTags =
     let scrubText patterns =
-        patterns
-        |> Rgx.scrubMatches
+        Rgx.scrubMatches patterns
+        >> String.stripWhiteSpace
         >> String.stripPunctuation
         >> String.stripDiacritics
 

--- a/src/AudioTagTools.DuplicateFinder/Tags.fs
+++ b/src/AudioTagTools.DuplicateFinder/Tags.fs
@@ -12,6 +12,7 @@ open CCFSharpUtils.Operators
 open CCFSharpUtils.Text
 open System
 open System.IO
+open System.Text.RegularExpressions
 
 let parseToTags json =
     json |> parseJsonToNonEmptyTags |!! TagParseError
@@ -23,6 +24,8 @@ let printCount description (tags: LibraryTags nlist) =
 let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
     : Result<LibraryTags nlist, CommandError> =
 
+    let matchOptions = RegexOptions.IgnoreCase
+
     let isExcluded tags =
         let (|ArtistAndTitle|ArtistOnly|TitleOnly|Invalid|) (excl: Exclusion) =
             match excl.Artist, excl.Title with
@@ -31,11 +34,12 @@ let discardExcluded (settings: Settings) (allTags: LibraryTags nlist)
             | None,   Some t -> TitleOnly t
             | _ -> Invalid
 
-        let containsArtist artistName =
+        let containsArtist artistPattern =
             [| tags.AlbumArtists; tags.Artists |]
-            |> Array.anyContainsIgnoreCase artistName
+            |> Array.concat
+            |> Array.exists (fun artist -> Regex.IsMatch(artist, artistPattern, matchOptions))
 
-        let titleStartsWith title = tags.Title |> String.startsWithIgnoreCase title
+        let titleStartsWith pattern = Regex.IsMatch(tags.Title, pattern, matchOptions)
 
         let checkIfExcluded = function
             | ArtistAndTitle (a, t) -> containsArtist a && titleStartsWith t


### PR DESCRIPTION
- In duplicate-finding, convert exclusions from plain text to regex searches, thus greatly increasing its search capabilities. A direct follow-up to #40.
- Change order of duplicates (to sorting by length)
- Nomenclature tweaks, etc.
- Add more information to the README