### PR TITLE
Add deleted count to caching results

### DIFF
--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -13,7 +13,7 @@ let private run args : Result<unit, CommandError> =
     monad {
         let! mediaDir, tagLibraryFile = validate args
         let! fileInfos = getFileInfos mediaDir
-        let! tagLibraryMap = createTagLibraryMap tagLibraryFile
+        let! tagLibraryMap = createTagLibMap tagLibraryFile
         let! newJson = fileInfos |> generateJson tagLibraryMap
 
         let _ =

--- a/src/AudioTagTools.Cacher/Library.fs
+++ b/src/AudioTagTools.Cacher/Library.fs
@@ -11,20 +11,20 @@ open FSharpPlus
 
 let private run args : Result<unit, CommandError> =
     monad {
-        let! mediaDir, tagLibraryFile = validate args
-        let! fileInfos = getFileInfos mediaDir
-        let! tagLibraryMap = createTagLibMap tagLibraryFile
-        let! newJson = fileInfos |> generateJson tagLibraryMap
+        let! mediaDir, tagLibFile = validate args
+        let! files = getFileInfos mediaDir
+        let! tagLibMap = createTagLibMap tagLibFile
+        let! newJson = files |> generateJson tagLibMap
 
         let _ =
-            backUpFile tagLibraryFile
+            backUpFile tagLibFile
             |-- printfn "Backed up previous file to \"%O\"."
             |!! FileWriteError
 
         do!
             newJson
-            |> File.writeText' tagLibraryFile
-            |-- fun _ -> printfn $"Wrote new file \"%O{tagLibraryFile}\"."
+            |> File.writeText' tagLibFile
+            |-- fun _ -> printfn $"Wrote new file \"%O{tagLibFile}\"."
             |!! FileWriteError
     }
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -96,7 +96,7 @@ let private countDeletedFiles tagLibraryMap categorizedTags =
 
     let orphanedLibraryTagCount =
         tagLibraryMap
-        |> Map.filter (fun libraryPath _ -> not (filePaths |> NList.contains libraryPath))
+        |> Map.filter (fun libPath _ -> filePaths |> NList.contains libPath |> not)
         |> _.Count
         |> uint
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -108,11 +108,11 @@ let private reportResults (categorizedTags, DeletedFileCount deletedCount) : uni
     let grandTotal = categoryTotals |> Map.values |> sum |> String.formatInt
 
     printfn "Results:"
-    printfn "• New:         %s" (countOf NewFile)
-    printfn "• Deleted:     %s" (String.formatNumber deletedCount)
-    printfn "• Out of sync: %s" (countOf LibOutOfDate + countOf FileOutOfDate)
-    printfn "• Unchanged:   %s" (countOf UpToDate)
-    printfn "• Total:       %s" grandTotal
+    printfn "+ New:         %s" (countOf NewFile)
+    printfn "+ Out of sync: %s" (countOf LibOutOfDate + countOf FileOutOfDate)
+    printfn "+ Unchanged:   %s" (countOf UpToDate)
+    printfn "- Deleted:     %s" (String.formatNumber deletedCount)
+    printfn "= New Total:   %s" grandTotal
 
 let generateJson tagMap fileInfos : Result<string, CommandError> =
     fileInfos

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -14,13 +14,12 @@ open FSharpPlus.Data
 open FSharpPlus.Operators
 
 module NList = NonEmptyList
-module NSeq = NonEmptySeq
+module NSeq =  NonEmptySeq
 
 type private LibPathTagMap = Map<FilePath, LibraryTags>
-
-type private ComparisonResult = UpToDate | OutOfSync | NewFile | FileDeleted
-
-type private NewLibTags = { Status: ComparisonResult; Tags: LibraryTags option }
+type private ComparisonResult = UpToDate | OutOfSync | NewFile
+type private NewLibTags = { Status: ComparisonResult; Tags: LibraryTags }
+type private DeletedCount = DeletedCount of uint
 
 let createTagLibMap (libFile: FileInfo) : Result<LibPathTagMap, CommandError> =
     if libFile.Exists
@@ -70,59 +69,46 @@ let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
         then
             let libTags = tagLibMap |> Map.find audioFile.FullName
             match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
-            | EQ -> { Status = UpToDate;  Tags = Some (copyCachedTags libTags) }
-            | _  -> { Status = OutOfSync; Tags = Some (generateNewTags audioFile) }
-        else { Status = NewFile; Tags = Some (generateNewTags audioFile) }
+            | EQ -> { Status = UpToDate;  Tags = copyCachedTags libTags }
+            | _  -> { Status = OutOfSync; Tags = generateNewTags audioFile }
+        else { Status = NewFile; Tags = generateNewTags audioFile }
 
     audioFiles |> NSeq.map (prepareTagsToCache libMap)
 
-let private appendDeletedFiles tagLibMap groupedNewLibTags : NewLibTags nseq =
+let private countDeletedFiles libMap groupedNewLibTags : NewLibTags nseq * DeletedCount =
     let filePaths =
         groupedNewLibTags
-        |> NSeq.choose (fun t -> t.Tags |> Option.map filePath)
+        |> NSeq.map (fun t -> filePath t.Tags)
         |> set
 
-    let orphanedLibTags = // Only used for counts.
-        tagLibMap
+    let deletedLibFileCount =
+        libMap
         |> Map.filter (fun libPath _ -> not (filePaths |> Set.contains libPath))
         |> Map.values
-        |> Seq.map (fun _ -> { Status = FileDeleted; Tags = None })
-        |> NSeq.tryOfSeq
+        |> _.Count
+        |> uint
 
-    match orphanedLibTags with
-    | Some t -> groupedNewLibTags |> NSeq.append t
-    | None   -> groupedNewLibTags
+    (groupedNewLibTags, DeletedCount deletedLibFileCount)
 
-let private printCounts groupedNewLibTags : unit =
-    let categoryTotals =
-        groupedNewLibTags
-        |> NSeq.countBy _.Status
-        |> Map.ofSeq
+let private printCounts (groupedNewLibTags, DeletedCount deletedCount) : unit =
+    let categoryTotals = groupedNewLibTags |> NSeq.countBy _.Status |> Map.ofSeq
 
-    let countOf category =
-        categoryTotals
-        |> Map.tryFindElse category 0
-        |> String.formatInt
+    let countOf category = categoryTotals |> Map.tryFindElse category 0 |> String.formatInt
 
-    let libTagCount =
-        categoryTotals
-        |> Map.filter (fun x _ -> not x.IsFileDeleted)
-        |> Map.values
-        |> sum
-        |> String.formatInt
+    let newLibTagCount = categoryTotals |> Map.values |> sum |> String.formatInt
 
     printfn "Results:"
     printfn "+ New:         %s" (countOf NewFile)
     printfn "+ Out of sync: %s" (countOf OutOfSync)
     printfn "+ Unchanged:   %s" (countOf UpToDate)
-    printfn "- Deleted:     %s" (countOf FileDeleted)
-    printfn "= New Total:   %s" libTagCount
+    printfn "- Deleted:     %s" (String.formatNumber deletedCount)
+    printfn "= New Total:   %s" newLibTagCount
 
 let generateJson tagMap audioFiles : Result<string, CommandError> =
     audioFiles
     |> generateNewLibTags tagMap
-    |> appendDeletedFiles tagMap
+    |> countDeletedFiles tagMap
     |- printCounts
-    |> map _.Tags
+    |> (fst >> map _.Tags)
     |> String.toJson
     |!! JsonSerializationError

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -75,34 +75,29 @@ let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
 
     audioFiles |> NSeq.map (prepareTagsToCache libMap)
 
-let private countDeletedFiles libMap groupedNewLibTags : NewLibTags nseq * DeletedCount =
-    let filePaths =
-        groupedNewLibTags
-        |> NSeq.map (fun t -> filePath t.Tags)
-        |> set
+let private countDeletedFiles libMap categorizedTags : NewLibTags nseq * DeletedCount =
+    let filePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> set
 
-    let deletedLibFileCount =
+    let deletedCount =
         libMap
         |> Map.filter (fun libPath _ -> not (filePaths |> Set.contains libPath))
-        |> Map.values
-        |> _.Count
-        |> uint
+        |> Map.values |> _.Count |> uint
 
-    (groupedNewLibTags, DeletedCount deletedLibFileCount)
+    (categorizedTags, DeletedCount deletedCount)
 
-let private printCounts (groupedNewLibTags, DeletedCount deletedCount) : unit =
-    let categoryTotals = groupedNewLibTags |> NSeq.countBy _.Status |> Map.ofSeq
+let private printCounts (categorizedTags, DeletedCount deletedCount) : unit =
+    let categoryTotals = categorizedTags |> NSeq.countBy _.Status |> Map.ofSeq
+
+    let newItemCount = categoryTotals |> Map.values |> sum |> String.formatInt
 
     let countOf category = categoryTotals |> Map.tryFindElse category 0 |> String.formatInt
 
-    let newLibTagCount = categoryTotals |> Map.values |> sum |> String.formatInt
-
     printfn "Results:"
-    printfn "  New:         %s" (countOf NewFile)
     printfn "  Deleted:     %s" (String.formatNumber deletedCount)
+    printfn "  New:         %s" (countOf NewFile)
     printfn "  Out of sync: %s" (countOf OutOfSync)
     printfn "  Unchanged:   %s" (countOf UpToDate)
-    printfn "  New Total:   %s" newLibTagCount
+    printfn "  New Total:   %s" newItemCount
 
 let generateJson tagMap audioFiles : Result<string, CommandError> =
     audioFiles

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -106,7 +106,7 @@ let private reportResults (categorizedTags, DeletedFileCount deletedCount) : uni
         |> Map.tryFindElse comparisonResult 0
         |> String.formatInt
 
-    let grandTotal = categoryTotals |> Map.values |> Seq.sum |> String.formatInt
+    let grandTotal = categoryTotals |> Map.values |> sum |> String.formatInt
 
     printfn "Results:"
     printfn "• New:         %s" (countOf NewFile)

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -89,7 +89,6 @@ let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache 
 let private countDeletedFiles (tagLibraryMap: Map<string,LibraryTags>) (categorizedTags: CategorizedTagsToCache nseq) =
     let libraryFilePaths =
         categorizedTags
-        // |> NonEmptySeq.choose (fun x -> match x.Tags with Some t -> Some (filePath t) | None -> None)
         |> NonEmptySeq.map (fun t -> filePath t.Tags)
         |> NonEmptyList.ofNonEmptySeq
 
@@ -97,11 +96,9 @@ let private countDeletedFiles (tagLibraryMap: Map<string,LibraryTags>) (categori
         tagLibraryMap
         |> Map.filter (fun k _ -> not (libraryFilePaths |> NonEmptyList.contains k))
 
-    // {| CategorizedTags = libraryTagsWithNoFile; DeletedCount = libraryTagsWithNoFile.Count |}
     (categorizedTags, DeletedItemCount libraryTagsWithNoFile.Count)
 
 let private reportResults (categorizedTags, DeletedItemCount deletedCount) : CategorizedTagsToCache nseq =
-
     let categoryTotals =
         categorizedTags
         |> Seq.countBy _.Type
@@ -119,12 +116,12 @@ let private reportResults (categorizedTags, DeletedItemCount deletedCount) : Cat
         |> String.formatInt
 
     printfn "Results:"
-    printfn "• New:       %s" (countOf FileToAdd)
-    printfn "• Updated:   %s" (countOf FileUpdated)
-    printfn "• Unchanged: %s" (countOf FileUnchanged)
-    printfn "• File Old*: %s" (countOf FileIsOlder) // TODO: Maybe combine?
-    printfn "• Deleted  : %s" (String.formatNumber deletedCount)
-    printfn "• Total:     %s" grandTotal
+    printfn "• New:          %s" (countOf FileToAdd)
+    printfn "• Deleted:      %s" (String.formatNumber deletedCount)
+    printfn "• File Updated: %s" (countOf FileUpdated)
+    printfn "• Lib. Updated: %s" (countOf FileIsOlder) // TODO: Maybe combine?
+    printfn "• Unchanged:    %s" (countOf FileUnchanged)
+    printfn "• Total:        %s" grandTotal
 
     categorizedTags
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -100,19 +100,16 @@ let private countDeletedFiles tagLibMap categorizedTags =
 let private reportResults (categorizedTags, DeletedFileCount deletedCount) : unit =
     let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
 
-    let countOf comparisonResult =
-        categoryTotals
-        |> Map.tryFindElse comparisonResult 0
-        |> String.formatInt
+    let countOf comparisonResult = categoryTotals |> Map.tryFindElse comparisonResult 0 |> String.formatInt
 
-    let grandTotal = categoryTotals |> Map.values |> sum |> String.formatInt
+    let grandTotal = categoryTotals |> Map.values |> sum
 
     printfn "Results:"
     printfn "+ New:         %s" (countOf NewFile)
     printfn "+ Out of sync: %s" (countOf LibOutOfDate + countOf FileOutOfDate)
     printfn "+ Unchanged:   %s" (countOf UpToDate)
     printfn "- Deleted:     %s" (String.formatNumber deletedCount)
-    printfn "= New Total:   %s" grandTotal
+    printfn "= New Total:   %s" (String.formatInt grandTotal)
 
 let generateJson tagMap fileInfos : Result<string, CommandError> =
     fileInfos

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -88,19 +88,16 @@ let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache 
     fileInfos
     |> NSeq.map (prepareTagsToCache tagLibraryMap)
 
-let private countDeletedFiles tagLibraryMap categorizedTags =
-    let filePaths =
-        categorizedTags
-        |> NSeq.map (fun t -> filePath t.Tags)
-        |> NList.ofNonEmptySeq
+let private countDeletedFiles tagLibMap categorizedTags =
+    let filePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> set
 
-    let orphanedLibraryTagCount =
-        tagLibraryMap
-        |> Map.filter (fun libPath _ -> filePaths |> NList.contains libPath |> not)
+    let orphanedLibTagCount =
+        tagLibMap
+        |> Map.filter (fun libPath _ -> not (filePaths |> Set.contains libPath))
         |> _.Count
         |> uint
 
-    (categorizedTags, DeletedItemCount orphanedLibraryTagCount)
+    (categorizedTags, DeletedItemCount orphanedLibTagCount)
 
 let private reportResults (categorizedTags, DeletedItemCount deletedCount) : CategorizedTagsToCache nseq =
     let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -72,15 +72,15 @@ let private prepareTagsToCache tagLibMap fileInfos : TagsToCache nseq =
 
        match parseFileTags fileInfo with
        | Ok (Some tags) -> tagsFromFile tags
-       | _ -> blankTags fileInfo
+       | _              -> blankTags fileInfo
 
     let prepareTagsToCache tagLibMap (audioFile: FileInfo) : TagsToCache =
         if tagLibMap |> Map.containsKey audioFile.FullName
         then
             let libTags = tagLibMap |> Map.find audioFile.FullName
             match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
-            | GT -> { Type = LibOutOfDate; Tags = generateNewTags audioFile }
             | EQ -> { Type = UpToDate; Tags = copyCachedTags libTags }
+            | GT -> { Type = LibOutOfDate; Tags = generateNewTags audioFile }
             | LT -> { Type = FileOutOfDate; Tags = generateNewTags audioFile }
         else { Type = NewFile; Tags = generateNewTags audioFile }
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -20,7 +20,7 @@ type LibraryTagMap = Map<FilePath, LibraryTags>
 
 type LibraryComparisonResult =
     | UpToDate // Library tags match file tags.
-    | LibraryOutOfDate // Library tags are older than file tags.
+    | LibOutOfDate // Library tags are older than file tags.
     | FileOutOfDate // Library tags are newer than file tags.
     | NewFile // No tags for file exist in library yet.
     | FileDeleted // Library tags exist, but file is now missing.
@@ -79,7 +79,7 @@ let private prepareTagsToCache tagLibMap fileInfos : TagsToCache nseq =
         then
             let libTags = tagLibMap |> Map.find audioFile.FullName
             match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
-            | GT -> { Type = LibraryOutOfDate; Tags = generateNewTags audioFile }
+            | GT -> { Type = LibOutOfDate; Tags = generateNewTags audioFile }
             | EQ -> { Type = UpToDate; Tags = copyCachedTags libTags }
             | LT -> { Type = FileOutOfDate; Tags = generateNewTags audioFile }
         else { Type = NewFile; Tags = generateNewTags audioFile }
@@ -111,7 +111,7 @@ let private reportResults (categorizedTags, DeletedFileCount deletedCount) : uni
     printfn "Results:"
     printfn "• New:         %s" (countOf NewFile)
     printfn "• Deleted:     %s" (String.formatNumber deletedCount)
-    printfn "• Out of sync: %s" (countOf LibraryOutOfDate + countOf FileOutOfDate)
+    printfn "• Out of sync: %s" (countOf LibOutOfDate + countOf FileOutOfDate)
     printfn "• Unchanged:   %s" (countOf UpToDate)
     printfn "• Total:       %s" grandTotal
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -101,9 +101,9 @@ let private countDeletedFiles tagLibMap categorizedTags =
 let private reportResults (categorizedTags, DeletedFileCount deletedCount) : unit =
     let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
 
-    let countOf comparisonResultType =
+    let countOf comparisonResult =
         categoryTotals
-        |> Map.tryFindElse comparisonResultType 0
+        |> Map.tryFindElse comparisonResult 0
         |> String.formatInt
 
     let grandTotal = categoryTotals |> Map.values |> Seq.sum |> String.formatInt

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -18,7 +18,7 @@ module NSeq =  NonEmptySeq
 
 type private LibPathTagMap = Map<FilePath, LibraryTags>
 
-type private ComparisonResult = UpToDate | OutOfSync | NewFile
+type private ComparisonResult = Unchanged | OutOfSync | NewFile
 
 type private NewLibTags = { Status: ComparisonResult; Tags: LibraryTags }
 
@@ -67,7 +67,7 @@ let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
         match tagLibMap |> Map.tryFind audioFile.FullName with
         | Some libTags ->
             match audioFile.LastWriteTime |> compareWith libTags.LastWriteTime.DateTime with
-            | EQ -> { Status = UpToDate;  Tags = copyLibTags libTags }
+            | EQ -> { Status = Unchanged;  Tags = copyLibTags libTags }
             | _  -> { Status = OutOfSync; Tags = generateNewTags audioFile }
         | None ->   { Status = NewFile;   Tags = generateNewTags audioFile }
 
@@ -94,7 +94,7 @@ let private printCounts (categorizedTags, DeletedCount deletedCount) : unit =
     printfn "  Deleted:     %s" (String.formatNumber deletedCount)
     printfn "  New:         %s" (countOf NewFile)
     printfn "  Out of sync: %s" (countOf OutOfSync)
-    printfn "  Unchanged:   %s" (countOf UpToDate)
+    printfn "  Unchanged:   %s" (countOf Unchanged)
     printfn "  New Total:   %s" newItemCount
 
 let generateJson tagMap audioFiles : Result<string, CommandError> =

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -19,11 +19,11 @@ module NSeq = NonEmptySeq
 type LibraryTagMap = Map<FilePath, LibraryTags>
 
 type LibraryComparisonResult =
-    | FileUnchanged  // Library tags match file tags.
-    | FileUpdated  // Library tags are older than file tags.
-    | FileIsOlder
-    | FileToAdd // No tags exist in library for file.
-    | FileDeleted // Tags exist, but file is now missing.
+    | UpToDate // Library tags match file tags.
+    | LibraryOutOfDate // Library tags are older than file tags.
+    | FileOutOfDate // Library tags are newer than file tags.
+    | NewFile // No tags for file exist in library yet.
+    | FileDeleted // Library tags exist, but file is now missing.
 
 type DeletedItemCount = DeletedFileCount of uint
 
@@ -80,10 +80,10 @@ let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache 
         then
             let libraryTags = tagLibraryMap |> Map.find audioFile.FullName
             match compareWith libraryTags.LastWriteTime.DateTime audioFile.LastWriteTime with
-            | GT -> { Type = FileUpdated; Tags = generateNewTags audioFile }
-            | EQ -> { Type = FileUnchanged; Tags = copyCachedTags libraryTags }
-            | LT -> { Type = FileIsOlder; Tags = generateNewTags audioFile }
-        else { Type = FileToAdd; Tags = generateNewTags audioFile }
+            | GT -> { Type = LibraryOutOfDate; Tags = generateNewTags audioFile }
+            | EQ -> { Type = UpToDate; Tags = copyCachedTags libraryTags }
+            | LT -> { Type = FileOutOfDate; Tags = generateNewTags audioFile }
+        else { Type = NewFile; Tags = generateNewTags audioFile }
 
     fileInfos
     |> NSeq.map (prepareTagsToCache tagLibraryMap)
@@ -110,12 +110,11 @@ let private reportResults (categorizedTags, DeletedFileCount deletedCount) : Cat
     let grandTotal = categoryTotals |> Map.values |> Seq.sum |> String.formatInt
 
     printfn "Results:"
-    printfn "• New:          %s" (countOf FileToAdd)
-    printfn "• Deleted:      %s" (String.formatNumber deletedCount)
-    printfn "• File Updated: %s" (countOf FileUpdated)
-    printfn "• Lib. Updated: %s" (countOf FileIsOlder) // TODO: Rare case. Maybe combine?
-    printfn "• Unchanged:    %s" (countOf FileUnchanged)
-    printfn "• Total:        %s" grandTotal
+    printfn "• New:         %s" (countOf NewFile)
+    printfn "• Deleted:     %s" (String.formatNumber deletedCount)
+    printfn "• Out of sync: %s" (countOf LibraryOutOfDate + countOf FileOutOfDate)
+    printfn "• Unchanged:   %s" (countOf UpToDate)
+    printfn "• Total:       %s" grandTotal
 
     categorizedTags
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -99,7 +99,7 @@ let private countDeletedFiles tagLibMap categorizedTags =
 
     (categorizedTags, DeletedFileCount orphanedLibTagCount)
 
-let private reportResults (categorizedTags, DeletedFileCount deletedCount) : CategorizedTagsToCache nseq =
+let private reportResults (categorizedTags, DeletedFileCount deletedCount) : unit =
     let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
 
     let countOf comparisonResultType =
@@ -116,13 +116,11 @@ let private reportResults (categorizedTags, DeletedFileCount deletedCount) : Cat
     printfn "• Unchanged:   %s" (countOf UpToDate)
     printfn "• Total:       %s" grandTotal
 
-    categorizedTags
-
 let generateJson tagMap fileInfos : Result<string, CommandError> =
     fileInfos
     |> prepareTagsToWrite tagMap
     |> countDeletedFiles tagMap
-    |> reportResults
-    |> map _.Tags
+    |- reportResults
+    |> (fst >> map _.Tags)
     |> String.toJson
     |!! JsonSerializationError

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -18,7 +18,7 @@ module NSeq = NonEmptySeq
 
 type LibTagMap = Map<FilePath, LibraryTags>
 
-type LibraryComparisonResult =
+type LibComparisonResult =
     | UpToDate // Library tags match file tags.
     | LibOutOfDate // Library tags are older than file tags.
     | FileOutOfDate // Library tags are newer than file tags.
@@ -28,7 +28,7 @@ type LibraryComparisonResult =
 type DeletedItemCount = DeletedFileCount of uint
 
 type TagsToCache =
-    { Type: LibraryComparisonResult
+    { Type: LibComparisonResult
       Tags: LibraryTags }
 
 let createTagLibMap (libFile: FileInfo) : Result<LibTagMap, CommandError> =
@@ -80,12 +80,11 @@ let private prepareTagsToCache tagLibMap fileInfos : TagsToCache nseq =
             let libTags = tagLibMap |> Map.find audioFile.FullName
             match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
             | EQ -> { Type = UpToDate; Tags = copyCachedTags libTags }
-            | GT -> { Type = LibOutOfDate; Tags = generateNewTags audioFile }
+            | GT -> { Type = LibOutOfDate;  Tags = generateNewTags audioFile }
             | LT -> { Type = FileOutOfDate; Tags = generateNewTags audioFile }
         else { Type = NewFile; Tags = generateNewTags audioFile }
 
-    fileInfos
-    |> NSeq.map (prepareTagsToCache tagLibMap)
+    fileInfos |> NSeq.map (prepareTagsToCache tagLibMap)
 
 let private countDeletedFiles tagLibMap categorizedTags =
     let filePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> set

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -65,13 +65,12 @@ let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
        | _              -> blankTags file
 
     let prepareTagsToCache tagLibMap (audioFile: FileInfo) : NewLibTags =
-        if tagLibMap |> Map.containsKey audioFile.FullName
-        then
-            let libTags = tagLibMap |> Map.find audioFile.FullName
-            match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
+        match tagLibMap |> Map.tryFind audioFile.FullName with
+        | Some libTags ->
+            match audioFile.LastWriteTime |> compareWith libTags.LastWriteTime.DateTime with
             | EQ -> { Status = UpToDate;  Tags = copyCachedTags libTags }
             | _  -> { Status = OutOfSync; Tags = generateNewTags audioFile }
-        else { Status = NewFile; Tags = generateNewTags audioFile }
+        | None ->   { Status = NewFile;   Tags = generateNewTags audioFile }
 
     audioFiles |> NSeq.map (prepareTagsToCache libMap)
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -25,7 +25,7 @@ type LibraryComparisonResult =
     | FileToAdd // No tags exist in library for file.
     | FileDeleted // Tags exist, but file is now missing.
 
-type DeletedItemCount = DeletedItemCount of uint
+type DeletedItemCount = DeletedFileCount of uint
 
 type CategorizedTagsToCache =
     { Type: LibraryComparisonResult
@@ -97,9 +97,9 @@ let private countDeletedFiles tagLibMap categorizedTags =
         |> _.Count
         |> uint
 
-    (categorizedTags, DeletedItemCount orphanedLibTagCount)
+    (categorizedTags, DeletedFileCount orphanedLibTagCount)
 
-let private reportResults (categorizedTags, DeletedItemCount deletedCount) : CategorizedTagsToCache nseq =
+let private reportResults (categorizedTags, DeletedFileCount deletedCount) : CategorizedTagsToCache nseq =
     let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
 
     let countOf comparisonResultType =

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -98,11 +98,11 @@ let private printCounts (groupedNewLibTags, DeletedCount deletedCount) : unit =
     let newLibTagCount = categoryTotals |> Map.values |> sum |> String.formatInt
 
     printfn "Results:"
-    printfn "+ New:         %s" (countOf NewFile)
-    printfn "+ Out of sync: %s" (countOf OutOfSync)
-    printfn "+ Unchanged:   %s" (countOf UpToDate)
-    printfn "- Deleted:     %s" (String.formatNumber deletedCount)
-    printfn "= New Total:   %s" newLibTagCount
+    printfn "  New:         %s" (countOf NewFile)
+    printfn "  Deleted:     %s" (String.formatNumber deletedCount)
+    printfn "  Out of sync: %s" (countOf OutOfSync)
+    printfn "  Unchanged:   %s" (countOf UpToDate)
+    printfn "  New Total:   %s" newLibTagCount
 
 let generateJson tagMap audioFiles : Result<string, CommandError> =
     audioFiles

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -31,40 +31,40 @@ let createTagLibMap (libFile: FileInfo) : Result<LibPathTagMap, CommandError> =
     else
         Ok Map.empty
 
+let private generateLibTags (file: FileInfo) (fileTags: FileTags) : LibraryTags =
+    {
+        FileName = file.Name
+        DirectoryName = file.DirectoryName
+        Artists = fileTags.Tag.Performers |> Array.map _.Normalize()
+        AlbumArtists = fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
+        Album = fileTags.Tag.Album |> Option.ofObj |> Option.defaultValue String.Empty |> _.Normalize()
+        DiscNo = fileTags.Tag.Disc
+        TrackNo = fileTags.Tag.Track
+        Title = fileTags.Tag.Title |> Option.ofObj |> Option.defaultValue String.Empty |> _.Normalize()
+        Year = fileTags.Tag.Year
+        Genres = fileTags.Tag.Genres
+        Duration = fileTags.Properties.Duration
+        BitRate = fileTags.Properties.AudioBitrate
+        SampleRate = fileTags.Properties.AudioSampleRate
+        FileSize = file.Length
+        ImageCount = fileTags.Tag.Pictures.Length
+        LastWriteTime = DateTimeOffset file.LastWriteTime
+    }
+
+let private generateNewTags (audioFile: FileInfo) : LibraryTags =
+    match parseFileTags audioFile with
+    | Ok (Some tags) -> generateLibTags audioFile tags
+    | _              -> emptyTags audioFile
+
 let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
-    let copyCachedTags libTags =
-        { libTags with LastWriteTime = DateTimeOffset libTags.LastWriteTime.DateTime }
-
-    let generateNewTags (file: FileInfo) : LibraryTags =
-       let tagsFromFile (fileTags: FileTags) =
-            {
-                FileName = file.Name
-                DirectoryName = file.DirectoryName
-                Artists = fileTags.Tag.Performers |> Array.map _.Normalize()
-                AlbumArtists = fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
-                Album = fileTags.Tag.Album |> Option.ofObj |> Option.defaultValue String.Empty |> _.Normalize()
-                DiscNo = fileTags.Tag.Disc
-                TrackNo = fileTags.Tag.Track
-                Title = fileTags.Tag.Title |> Option.ofObj |> Option.defaultValue String.Empty |> _.Normalize()
-                Year = fileTags.Tag.Year
-                Genres = fileTags.Tag.Genres
-                Duration = fileTags.Properties.Duration
-                BitRate = fileTags.Properties.AudioBitrate
-                SampleRate = fileTags.Properties.AudioSampleRate
-                FileSize = file.Length
-                ImageCount = fileTags.Tag.Pictures.Length
-                LastWriteTime = DateTimeOffset file.LastWriteTime
-            }
-
-       match parseFileTags file with
-       | Ok (Some tags) -> tagsFromFile tags
-       | _              -> blankTags file
+    let copyLibTags tags =
+        { tags with LastWriteTime = DateTimeOffset tags.LastWriteTime.DateTime }
 
     let prepareTagsToCache tagLibMap (audioFile: FileInfo) : NewLibTags =
         match tagLibMap |> Map.tryFind audioFile.FullName with
         | Some libTags ->
             match audioFile.LastWriteTime |> compareWith libTags.LastWriteTime.DateTime with
-            | EQ -> { Status = UpToDate;  Tags = copyCachedTags libTags }
+            | EQ -> { Status = UpToDate;  Tags = copyLibTags libTags }
             | _  -> { Status = OutOfSync; Tags = generateNewTags audioFile }
         | None ->   { Status = NewFile;   Tags = generateNewTags audioFile }
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -31,7 +31,7 @@ type TagsToCache =
     { Type: LibraryComparisonResult
       Tags: LibraryTags }
 
-let createTagLibraryMap (libFile: FileInfo) : Result<LibraryTagMap, CommandError> =
+let createTagLibMap (libFile: FileInfo) : Result<LibraryTagMap, CommandError> =
     if libFile.Exists
     then
         File.readText' libFile

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -25,8 +25,7 @@ type LibraryComparisonResult =
     | FileToAdd // No tags exist in library for file.
     | FileDeleted // Tags exist, but file is now missing.
 
-// type FileData = FilePath * LibraryTags option
-type DeletedItemCount = DeletedItemCount of int
+type DeletedItemCount = DeletedItemCount of uint
 
 type CategorizedTagsToCache =
     { Type: LibraryComparisonResult
@@ -89,14 +88,19 @@ let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache 
     fileInfos
     |> NSeq.map (prepareTagsToCache tagLibraryMap)
 
-let private countDeletedFiles (tagLibraryMap: Map<string,LibraryTags>) (categorizedTags: CategorizedTagsToCache nseq) =
-    let libraryFilePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> NList.ofNonEmptySeq
+let private countDeletedFiles tagLibraryMap categorizedTags =
+    let filePaths =
+        categorizedTags
+        |> NSeq.map (fun t -> filePath t.Tags)
+        |> NList.ofNonEmptySeq
 
-    let libraryTagsWithNoFile =
+    let orphanedLibraryTagCount =
         tagLibraryMap
-        |> Map.filter (fun k _ -> not (libraryFilePaths |> NList.contains k))
+        |> Map.filter (fun libraryPath _ -> not (filePaths |> NList.contains libraryPath))
+        |> _.Count
+        |> uint
 
-    (categorizedTags, DeletedItemCount libraryTagsWithNoFile.Count)
+    (categorizedTags, DeletedItemCount orphanedLibraryTagCount)
 
 let private reportResults (categorizedTags, DeletedItemCount deletedCount) : CategorizedTagsToCache nseq =
     let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
@@ -112,7 +116,7 @@ let private reportResults (categorizedTags, DeletedItemCount deletedCount) : Cat
     printfn "• New:          %s" (countOf FileToAdd)
     printfn "• Deleted:      %s" (String.formatNumber deletedCount)
     printfn "• File Updated: %s" (countOf FileUpdated)
-    printfn "• Lib. Updated: %s" (countOf FileIsOlder) // TODO: Maybe combine?
+    printfn "• Lib. Updated: %s" (countOf FileIsOlder) // TODO: Rare case. Maybe combine?
     printfn "• Unchanged:    %s" (countOf FileUnchanged)
     printfn "• Total:        %s" grandTotal
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -13,6 +13,9 @@ open CCFSharpUtils.Text
 open FSharpPlus.Data
 open FSharpPlus.Operators
 
+module NList = NonEmptyList
+module NSeq = NonEmptySeq
+
 type LibraryTagMap = Map<FilePath, LibraryTags>
 
 type LibraryComparisonResult =
@@ -84,36 +87,26 @@ let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache 
         else { Type = FileToAdd; Tags = generateNewTags audioFile }
 
     fileInfos
-    |> NonEmptySeq.map (prepareTagsToCache tagLibraryMap)
+    |> NSeq.map (prepareTagsToCache tagLibraryMap)
 
 let private countDeletedFiles (tagLibraryMap: Map<string,LibraryTags>) (categorizedTags: CategorizedTagsToCache nseq) =
-    let libraryFilePaths =
-        categorizedTags
-        |> NonEmptySeq.map (fun t -> filePath t.Tags)
-        |> NonEmptyList.ofNonEmptySeq
+    let libraryFilePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> NList.ofNonEmptySeq
 
     let libraryTagsWithNoFile =
         tagLibraryMap
-        |> Map.filter (fun k _ -> not (libraryFilePaths |> NonEmptyList.contains k))
+        |> Map.filter (fun k _ -> not (libraryFilePaths |> NList.contains k))
 
     (categorizedTags, DeletedItemCount libraryTagsWithNoFile.Count)
 
 let private reportResults (categorizedTags, DeletedItemCount deletedCount) : CategorizedTagsToCache nseq =
-    let categoryTotals =
-        categorizedTags
-        |> Seq.countBy _.Type
-        |> Map.ofSeq
+    let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
 
     let countOf comparisonResultType =
         categoryTotals
         |> Map.tryFindElse comparisonResultType 0
         |> String.formatInt
 
-    let grandTotal =
-        categoryTotals
-        |> Map.values
-        |> Seq.sum
-        |> String.formatInt
+    let grandTotal = categoryTotals |> Map.values |> Seq.sum |> String.formatInt
 
     printfn "Results:"
     printfn "• New:          %s" (countOf FileToAdd)

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -76,20 +76,20 @@ let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
 
     audioFiles |> NSeq.map (prepareTagsToCache libMap)
 
-let private addDeletedFiles tagLibMap groupedNewLibTags : NewLibTags nseq =
+let private appendDeletedFiles tagLibMap groupedNewLibTags : NewLibTags nseq =
     let filePaths =
         groupedNewLibTags
         |> NSeq.choose (fun t -> t.Tags |> Option.map filePath)
         |> set
 
-    let orphanedLibFiles = // Only used for counts.
+    let orphanedLibTags = // Only used for counts.
         tagLibMap
         |> Map.filter (fun libPath _ -> not (filePaths |> Set.contains libPath))
         |> Map.values
         |> Seq.map (fun _ -> { Status = FileDeleted; Tags = None })
         |> NSeq.tryOfSeq
 
-    match orphanedLibFiles with
+    match orphanedLibTags with
     | Some t -> groupedNewLibTags |> NSeq.append t
     | None   -> groupedNewLibTags
 
@@ -121,7 +121,7 @@ let private printCounts groupedNewLibTags : unit =
 let generateJson tagMap audioFiles : Result<string, CommandError> =
     audioFiles
     |> generateNewLibTags tagMap
-    |> addDeletedFiles tagMap
+    |> appendDeletedFiles tagMap
     |- printCounts
     |> map _.Tags
     |> String.toJson

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -16,38 +16,31 @@ open FSharpPlus.Operators
 module NList = NonEmptyList
 module NSeq = NonEmptySeq
 
-type private LibTagMap = Map<FilePath, LibraryTags>
+type private LibPathTagMap = Map<FilePath, LibraryTags>
 
-type ComparisonResult =
-    | UpToDate // Library tags match file tags.
-    | LibOutOfDate // Library tags are older than file tags.
-    | FileOutOfDate // Library tags are newer than file tags.
-    | NewFile // No tags for file exist in library yet.
-    | FileDeleted // Library tags exist, but file is now missing.
+type private ComparisonResult = UpToDate | LibOutOfDate | FileOutOfDate | NewFile | FileDeleted
 
-type TagsToCache =
-    { ComparisonResult: ComparisonResult
-      Tags: LibraryTags option }
+type private NewLibTags = { Status: ComparisonResult; Tags: LibraryTags option }
 
-let createTagLibMap (libFile: FileInfo) : Result<LibTagMap, CommandError> =
+let createTagLibMap (libFile: FileInfo) : Result<LibPathTagMap, CommandError> =
     if libFile.Exists
     then
         File.readText' libFile
         >>= (Json >> parseJsonToTags)
-        |>> (List.map groupByPath >> Map.ofList)
+        |>> (map groupByPath >> Map.ofList)
         |!! LibraryTagParseError
     else
         Ok Map.empty
 
-let private prepareTagsToCache tagLibMap fileInfos : TagsToCache nseq =
-    let copyCachedTags (libTags: LibraryTags) =
+let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
+    let copyCachedTags libTags =
         { libTags with LastWriteTime = DateTimeOffset libTags.LastWriteTime.DateTime }
 
-    let generateNewTags (fileInfo: FileInfo) : LibraryTags =
+    let generateNewTags (file: FileInfo) : LibraryTags =
        let tagsFromFile (fileTags: FileTags) =
             {
-                FileName = fileInfo.Name
-                DirectoryName = fileInfo.DirectoryName
+                FileName = file.Name
+                DirectoryName = file.DirectoryName
                 Artists = fileTags.Tag.Performers |> Array.map _.Normalize()
                 AlbumArtists = fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
                 Album = match fileTags.Tag.Album with
@@ -63,63 +56,69 @@ let private prepareTagsToCache tagLibMap fileInfos : TagsToCache nseq =
                 Duration = fileTags.Properties.Duration
                 BitRate = fileTags.Properties.AudioBitrate
                 SampleRate = fileTags.Properties.AudioSampleRate
-                FileSize = fileInfo.Length
+                FileSize = file.Length
                 ImageCount = fileTags.Tag.Pictures.Length
-                LastWriteTime = DateTimeOffset fileInfo.LastWriteTime
+                LastWriteTime = DateTimeOffset file.LastWriteTime
             }
 
-       match parseFileTags fileInfo with
+       match parseFileTags file with
        | Ok (Some tags) -> tagsFromFile tags
-       | _              -> blankTags fileInfo
+       | _              -> blankTags file
 
-    let prepareTagsToCache tagLibMap (audioFile: FileInfo) : TagsToCache =
+    let prepareTagsToCache tagLibMap (audioFile: FileInfo) : NewLibTags =
         if tagLibMap |> Map.containsKey audioFile.FullName
         then
             let libTags = tagLibMap |> Map.find audioFile.FullName
             match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
-            | EQ -> { ComparisonResult = UpToDate; Tags = Some (copyCachedTags libTags) }
-            | GT -> { ComparisonResult = LibOutOfDate;  Tags = Some (generateNewTags audioFile) }
-            | LT -> { ComparisonResult = FileOutOfDate; Tags = Some (generateNewTags audioFile) }
-        else { ComparisonResult = NewFile; Tags = Some (generateNewTags audioFile) }
+            | EQ -> { Status = UpToDate;      Tags = Some (copyCachedTags libTags) }
+            | GT -> { Status = LibOutOfDate;  Tags = Some (generateNewTags audioFile) }
+            | LT -> { Status = FileOutOfDate; Tags = Some (generateNewTags audioFile) }
+        else { Status = NewFile; Tags = Some (generateNewTags audioFile) }
 
-    fileInfos |> NSeq.map (prepareTagsToCache tagLibMap)
+    audioFiles |> NSeq.map (prepareTagsToCache libMap)
 
-let private addDeletedFiles tagLibMap categorizedTags =
+let private addDeletedFiles tagLibMap groupedNewLibTags : NewLibTags nseq =
     let filePaths =
-        categorizedTags
-        |> NSeq.choose (fun t -> match t.Tags with Some t -> Some (filePath t) | None -> None)
+        groupedNewLibTags
+        |> NSeq.choose (fun t -> t.Tags |> Option.map filePath)
         |> set
 
-    let orphanedLibTags =
+    let orphanedLibFiles = // Only used for counts.
         tagLibMap
         |> Map.filter (fun libPath _ -> not (filePaths |> Set.contains libPath))
         |> Map.values
-        |> Seq.map (fun _ -> { ComparisonResult = FileDeleted; Tags = None })
+        |> Seq.map (fun _ -> { Status = FileDeleted; Tags = None })
         |> NSeq.tryOfSeq
 
-    match orphanedLibTags with
-    | Some t -> categorizedTags |> NSeq.append t
-    | None   -> categorizedTags
+    match orphanedLibFiles with
+    | Some t -> groupedNewLibTags |> NSeq.append t
+    | None   -> groupedNewLibTags
 
-let private reportResults categorizedTags : unit =
-    let categoryTotals = categorizedTags |> NSeq.countBy _.ComparisonResult |> Map.ofSeq
+let private printCounts groupedNewLibTags : unit =
+    let categoryTotals =
+        groupedNewLibTags
+        |> NSeq.countBy _.Status
+        |> Map.ofSeq
 
-    let countOf category = categoryTotals |> Map.tryFindElse category 0 |> String.formatInt
+    let countOf category =
+        categoryTotals
+        |> Map.tryFindElse category 0
+        |> String.formatInt
 
-    let grandTotal = categoryTotals |> Map.values |> sum
+    let grandTotal = categoryTotals |> Map.values |> sum |> String.formatInt
 
     printfn "Results:"
     printfn "+ New:         %s" (countOf NewFile)
     printfn "+ Out of sync: %s" (countOf LibOutOfDate + countOf FileOutOfDate)
     printfn "+ Unchanged:   %s" (countOf UpToDate)
     printfn "- Deleted:     %s" (countOf FileDeleted)
-    printfn "= New Total:   %s" (String.formatInt grandTotal)
+    printfn "= New Total:   %s" grandTotal
 
-let generateJson tagMap fileInfos : Result<string, CommandError> =
-    fileInfos
-    |> prepareTagsToCache tagMap
+let generateJson tagMap audioFiles : Result<string, CommandError> =
+    audioFiles
+    |> generateNewLibTags tagMap
     |> addDeletedFiles tagMap
-    |- reportResults
+    |- printCounts
     |> map _.Tags
     |> String.toJson
     |!! JsonSerializationError

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -20,7 +20,7 @@ type private LibPathTagMap = Map<FilePath, LibraryTags>
 
 type private ComparisonResult = Unchanged | OutOfSync | NewFile
 
-type private NewLibTags = { Status: ComparisonResult; Tags: LibraryTags }
+type private CheckedLibTags = { Status: ComparisonResult; Tags: LibraryTags }
 
 type private DeletedCount = DeletedCount of uint
 
@@ -34,6 +34,7 @@ let createTagLibMap (libFile: FileInfo) : Result<LibPathTagMap, CommandError> =
     else
         Ok Map.empty
 
+/// Gives new library tags that are tagged with the current time.
 let private generateLibTags (file: FileInfo) (fileTags: FileTags) : LibraryTags =
     {
         FileName = file.Name
@@ -59,21 +60,21 @@ let private generateNewTags (audioFile: FileInfo) : LibraryTags =
     | Ok (Some tags) -> generateLibTags audioFile tags
     | _              -> emptyTags audioFile
 
-let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
+let private checkAudioFiles libMap audioFiles : CheckedLibTags nseq =
     let copyLibTags tags =
         { tags with LastWriteTime = DateTimeOffset tags.LastWriteTime.DateTime }
 
-    let prepareTagsToCache tagLibMap (audioFile: FileInfo) : NewLibTags =
+    let prepareTagsToCache tagLibMap (audioFile: FileInfo) : CheckedLibTags =
         match tagLibMap |> Map.tryFind audioFile.FullName with
         | Some libTags ->
             match audioFile.LastWriteTime |> compareWith libTags.LastWriteTime.DateTime with
-            | EQ -> { Status = Unchanged;  Tags = copyLibTags libTags }
+            | EQ -> { Status = Unchanged; Tags = copyLibTags libTags }
             | _  -> { Status = OutOfSync; Tags = generateNewTags audioFile }
         | None ->   { Status = NewFile;   Tags = generateNewTags audioFile }
 
     audioFiles |> NSeq.map (prepareTagsToCache libMap)
 
-let private countDeletedFiles libMap categorizedTags : NewLibTags nseq * DeletedCount =
+let private countDeletedFiles libMap categorizedTags : CheckedLibTags nseq * DeletedCount =
     let filePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> set
 
     let deletedCount =
@@ -99,7 +100,7 @@ let private printCounts (categorizedTags, DeletedCount deletedCount) : unit =
 
 let generateJson tagMap audioFiles : Result<string, CommandError> =
     audioFiles
-    |> generateNewLibTags tagMap
+    |> checkAudioFiles tagMap
     |> countDeletedFiles tagMap
     |- printCounts
     |> (fst >> map _.Tags)

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -42,14 +42,10 @@ let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
                 DirectoryName = file.DirectoryName
                 Artists = fileTags.Tag.Performers |> Array.map _.Normalize()
                 AlbumArtists = fileTags.Tag.AlbumArtists |> Array.map _.Normalize()
-                Album = match fileTags.Tag.Album with
-                        | null  -> String.Empty
-                        | album -> album.Normalize()
+                Album = fileTags.Tag.Album |> Option.ofObj |> Option.defaultValue String.Empty |> _.Normalize()
                 DiscNo = fileTags.Tag.Disc
                 TrackNo = fileTags.Tag.Track
-                Title = match fileTags.Tag.Title with
-                        | null  -> String.Empty
-                        | title -> title.Normalize()
+                Title = fileTags.Tag.Title |> Option.ofObj |> Option.defaultValue String.Empty |> _.Normalize()
                 Year = fileTags.Tag.Year
                 Genres = fileTags.Tag.Genres
                 Duration = fileTags.Properties.Duration

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -16,9 +16,14 @@ open FSharpPlus.Operators
 type LibraryTagMap = Map<FilePath, LibraryTags>
 
 type LibraryComparisonResult =
-    | Unchanged  // Library tags match file tags.
-    | OutOfDate  // Library tags are older than file tags.
-    | NotPresent // No tags exist in library for file.
+    | FileUnchanged  // Library tags match file tags.
+    | FileUpdated  // Library tags are older than file tags.
+    | FileIsOlder
+    | FileToAdd // No tags exist in library for file.
+    | FileDeleted // Tags exist, but file is now missing.
+
+// type FileData = FilePath * LibraryTags option
+type DeletedItemCount = DeletedItemCount of int
 
 type CategorizedTagsToCache =
     { Type: LibraryComparisonResult
@@ -35,9 +40,7 @@ let createTagLibraryMap (libraryFile: FileInfo) : Result<LibraryTagMap, CommandE
     else
         Ok Map.empty
 
-let private prepareTagsToWrite tagLibraryMap fileInfos
-    : CategorizedTagsToCache nseq =
-
+let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache nseq =
     let copyCachedTags (libraryTags: LibraryTags) =
         { libraryTags with LastWriteTime = DateTimeOffset libraryTags.LastWriteTime.DateTime }
 
@@ -74,15 +77,30 @@ let private prepareTagsToWrite tagLibraryMap fileInfos
         if tagLibraryMap |> Map.containsKey audioFile.FullName
         then
             let libraryTags = tagLibraryMap |> Map.find audioFile.FullName
-            if libraryTags.LastWriteTime.DateTime < audioFile.LastWriteTime
-            then { Type = OutOfDate; Tags = generateNewTags audioFile }
-            else { Type = Unchanged; Tags = copyCachedTags libraryTags }
-        else { Type = NotPresent; Tags = generateNewTags audioFile }
+            match compareWith libraryTags.LastWriteTime.DateTime audioFile.LastWriteTime with
+            | GT -> { Type = FileUpdated; Tags = generateNewTags audioFile }
+            | EQ -> { Type = FileUnchanged; Tags = copyCachedTags libraryTags }
+            | LT -> { Type = FileIsOlder; Tags = generateNewTags audioFile }
+        else { Type = FileToAdd; Tags = generateNewTags audioFile }
 
     fileInfos
     |> NonEmptySeq.map (prepareTagsToCache tagLibraryMap)
 
-let private reportResults categorizedTags : CategorizedTagsToCache nseq =
+let private countDeletedFiles (tagLibraryMap: Map<string,LibraryTags>) (categorizedTags: CategorizedTagsToCache nseq) =
+    let libraryFilePaths =
+        categorizedTags
+        // |> NonEmptySeq.choose (fun x -> match x.Tags with Some t -> Some (filePath t) | None -> None)
+        |> NonEmptySeq.map (fun t -> filePath t.Tags)
+        |> NonEmptyList.ofNonEmptySeq
+
+    let libraryTagsWithNoFile =
+        tagLibraryMap
+        |> Map.filter (fun k _ -> not (libraryFilePaths |> NonEmptyList.contains k))
+
+    // {| CategorizedTags = libraryTagsWithNoFile; DeletedCount = libraryTagsWithNoFile.Count |}
+    (categorizedTags, DeletedItemCount libraryTagsWithNoFile.Count)
+
+let private reportResults (categorizedTags, DeletedItemCount deletedCount) : CategorizedTagsToCache nseq =
 
     let categoryTotals =
         categorizedTags
@@ -100,10 +118,12 @@ let private reportResults categorizedTags : CategorizedTagsToCache nseq =
         |> Seq.sum
         |> String.formatInt
 
-    printfn "Results:" // TODO: Add deleted.
-    printfn "• New:       %s" (countOf NotPresent)
-    printfn "• Updated:   %s" (countOf OutOfDate)
-    printfn "• Unchanged: %s" (countOf Unchanged)
+    printfn "Results:"
+    printfn "• New:       %s" (countOf FileToAdd)
+    printfn "• Updated:   %s" (countOf FileUpdated)
+    printfn "• Unchanged: %s" (countOf FileUnchanged)
+    printfn "• File Old*: %s" (countOf FileIsOlder) // TODO: Maybe combine?
+    printfn "• Deleted  : %s" (String.formatNumber deletedCount)
     printfn "• Total:     %s" grandTotal
 
     categorizedTags
@@ -111,6 +131,7 @@ let private reportResults categorizedTags : CategorizedTagsToCache nseq =
 let generateJson tagMap fileInfos : Result<string, CommandError> =
     fileInfos
     |> prepareTagsToWrite tagMap
+    |> countDeletedFiles tagMap
     |> reportResults
     |> NonEmptySeq.map _.Tags
     |> String.toJson

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -123,6 +123,6 @@ let generateJson tagMap fileInfos : Result<string, CommandError> =
     |> prepareTagsToWrite tagMap
     |> countDeletedFiles tagMap
     |> reportResults
-    |> NonEmptySeq.map _.Tags
+    |> map _.Tags
     |> String.toJson
     |!! JsonSerializationError

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -16,20 +16,18 @@ open FSharpPlus.Operators
 module NList = NonEmptyList
 module NSeq = NonEmptySeq
 
-type LibTagMap = Map<FilePath, LibraryTags>
+type private LibTagMap = Map<FilePath, LibraryTags>
 
-type LibComparisonResult =
+type ComparisonResult =
     | UpToDate // Library tags match file tags.
     | LibOutOfDate // Library tags are older than file tags.
     | FileOutOfDate // Library tags are newer than file tags.
     | NewFile // No tags for file exist in library yet.
     | FileDeleted // Library tags exist, but file is now missing.
 
-type DeletedItemCount = DeletedFileCount of uint
-
 type TagsToCache =
-    { Type: LibComparisonResult
-      Tags: LibraryTags }
+    { ComparisonResult: ComparisonResult
+      Tags: LibraryTags option }
 
 let createTagLibMap (libFile: FileInfo) : Result<LibTagMap, CommandError> =
     if libFile.Exists
@@ -79,26 +77,32 @@ let private prepareTagsToCache tagLibMap fileInfos : TagsToCache nseq =
         then
             let libTags = tagLibMap |> Map.find audioFile.FullName
             match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
-            | EQ -> { Type = UpToDate; Tags = copyCachedTags libTags }
-            | GT -> { Type = LibOutOfDate;  Tags = generateNewTags audioFile }
-            | LT -> { Type = FileOutOfDate; Tags = generateNewTags audioFile }
-        else { Type = NewFile; Tags = generateNewTags audioFile }
+            | EQ -> { ComparisonResult = UpToDate; Tags = Some (copyCachedTags libTags) }
+            | GT -> { ComparisonResult = LibOutOfDate;  Tags = Some (generateNewTags audioFile) }
+            | LT -> { ComparisonResult = FileOutOfDate; Tags = Some (generateNewTags audioFile) }
+        else { ComparisonResult = NewFile; Tags = Some (generateNewTags audioFile) }
 
     fileInfos |> NSeq.map (prepareTagsToCache tagLibMap)
 
-let private countDeletedFiles tagLibMap categorizedTags =
-    let filePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> set
+let private addDeletedFiles tagLibMap categorizedTags =
+    let filePaths =
+        categorizedTags
+        |> NSeq.choose (fun t -> match t.Tags with Some t -> Some (filePath t) | None -> None)
+        |> set
 
-    let orphanedLibTagCount =
+    let orphanedLibTags =
         tagLibMap
         |> Map.filter (fun libPath _ -> not (filePaths |> Set.contains libPath))
-        |> _.Count
-        |> uint
+        |> Map.values
+        |> Seq.map (fun _ -> { ComparisonResult = FileDeleted; Tags = None })
+        |> NSeq.tryOfSeq
 
-    (categorizedTags, DeletedFileCount orphanedLibTagCount)
+    match orphanedLibTags with
+    | Some t -> categorizedTags |> NSeq.append t
+    | None   -> categorizedTags
 
-let private reportResults (categorizedTags, DeletedFileCount deletedCount) : unit =
-    let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
+let private reportResults categorizedTags : unit =
+    let categoryTotals = categorizedTags |> NSeq.countBy _.ComparisonResult |> Map.ofSeq
 
     let countOf category = categoryTotals |> Map.tryFindElse category 0 |> String.formatInt
 
@@ -108,14 +112,14 @@ let private reportResults (categorizedTags, DeletedFileCount deletedCount) : uni
     printfn "+ New:         %s" (countOf NewFile)
     printfn "+ Out of sync: %s" (countOf LibOutOfDate + countOf FileOutOfDate)
     printfn "+ Unchanged:   %s" (countOf UpToDate)
-    printfn "- Deleted:     %s" (String.formatNumber deletedCount)
+    printfn "- Deleted:     %s" (countOf FileDeleted)
     printfn "= New Total:   %s" (String.formatInt grandTotal)
 
 let generateJson tagMap fileInfos : Result<string, CommandError> =
     fileInfos
     |> prepareTagsToCache tagMap
-    |> countDeletedFiles tagMap
+    |> addDeletedFiles tagMap
     |- reportResults
-    |> (fst >> map _.Tags)
+    |> map _.Tags
     |> String.toJson
     |!! JsonSerializationError

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -18,7 +18,7 @@ module NSeq = NonEmptySeq
 
 type private LibPathTagMap = Map<FilePath, LibraryTags>
 
-type private ComparisonResult = UpToDate | LibOutOfDate | FileOutOfDate | NewFile | FileDeleted
+type private ComparisonResult = UpToDate | OutOfSync | NewFile | FileDeleted
 
 type private NewLibTags = { Status: ComparisonResult; Tags: LibraryTags option }
 
@@ -70,9 +70,8 @@ let private generateNewLibTags libMap audioFiles : NewLibTags nseq =
         then
             let libTags = tagLibMap |> Map.find audioFile.FullName
             match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
-            | EQ -> { Status = UpToDate;      Tags = Some (copyCachedTags libTags) }
-            | GT -> { Status = LibOutOfDate;  Tags = Some (generateNewTags audioFile) }
-            | LT -> { Status = FileOutOfDate; Tags = Some (generateNewTags audioFile) }
+            | EQ -> { Status = UpToDate;  Tags = Some (copyCachedTags libTags) }
+            | _  -> { Status = OutOfSync; Tags = Some (generateNewTags audioFile) }
         else { Status = NewFile; Tags = Some (generateNewTags audioFile) }
 
     audioFiles |> NSeq.map (prepareTagsToCache libMap)
@@ -105,14 +104,19 @@ let private printCounts groupedNewLibTags : unit =
         |> Map.tryFindElse category 0
         |> String.formatInt
 
-    let grandTotal = categoryTotals |> Map.values |> sum |> String.formatInt
+    let libTagCount =
+        categoryTotals
+        |> Map.filter (fun x _ -> not x.IsFileDeleted)
+        |> Map.values
+        |> sum
+        |> String.formatInt
 
     printfn "Results:"
     printfn "+ New:         %s" (countOf NewFile)
-    printfn "+ Out of sync: %s" (countOf LibOutOfDate + countOf FileOutOfDate)
+    printfn "+ Out of sync: %s" (countOf OutOfSync)
     printfn "+ Unchanged:   %s" (countOf UpToDate)
     printfn "- Deleted:     %s" (countOf FileDeleted)
-    printfn "= New Total:   %s" grandTotal
+    printfn "= New Total:   %s" libTagCount
 
 let generateJson tagMap audioFiles : Result<string, CommandError> =
     audioFiles

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -100,7 +100,7 @@ let private countDeletedFiles tagLibMap categorizedTags =
 let private reportResults (categorizedTags, DeletedFileCount deletedCount) : unit =
     let categoryTotals = categorizedTags |> NSeq.countBy _.Type |> Map.ofSeq
 
-    let countOf comparisonResult = categoryTotals |> Map.tryFindElse comparisonResult 0 |> String.formatInt
+    let countOf category = categoryTotals |> Map.tryFindElse category 0 |> String.formatInt
 
     let grandTotal = categoryTotals |> Map.values |> sum
 

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -16,7 +16,7 @@ open FSharpPlus.Operators
 module NList = NonEmptyList
 module NSeq = NonEmptySeq
 
-type LibraryTagMap = Map<FilePath, LibraryTags>
+type LibTagMap = Map<FilePath, LibraryTags>
 
 type LibraryComparisonResult =
     | UpToDate // Library tags match file tags.
@@ -31,7 +31,7 @@ type TagsToCache =
     { Type: LibraryComparisonResult
       Tags: LibraryTags }
 
-let createTagLibMap (libFile: FileInfo) : Result<LibraryTagMap, CommandError> =
+let createTagLibMap (libFile: FileInfo) : Result<LibTagMap, CommandError> =
     if libFile.Exists
     then
         File.readText' libFile

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -17,8 +17,11 @@ module NList = NonEmptyList
 module NSeq =  NonEmptySeq
 
 type private LibPathTagMap = Map<FilePath, LibraryTags>
+
 type private ComparisonResult = UpToDate | OutOfSync | NewFile
+
 type private NewLibTags = { Status: ComparisonResult; Tags: LibraryTags }
+
 type private DeletedCount = DeletedCount of uint
 
 let createTagLibMap (libFile: FileInfo) : Result<LibPathTagMap, CommandError> =

--- a/src/AudioTagTools.Cacher/Tags.fs
+++ b/src/AudioTagTools.Cacher/Tags.fs
@@ -27,24 +27,23 @@ type LibraryComparisonResult =
 
 type DeletedItemCount = DeletedFileCount of uint
 
-type CategorizedTagsToCache =
+type TagsToCache =
     { Type: LibraryComparisonResult
       Tags: LibraryTags }
 
-let createTagLibraryMap (libraryFile: FileInfo) : Result<LibraryTagMap, CommandError> =
-    if libraryFile.Exists
+let createTagLibraryMap (libFile: FileInfo) : Result<LibraryTagMap, CommandError> =
+    if libFile.Exists
     then
-        libraryFile
-        |> File.readText'
+        File.readText' libFile
         >>= (Json >> parseJsonToTags)
         |>> (List.map groupByPath >> Map.ofList)
         |!! LibraryTagParseError
     else
         Ok Map.empty
 
-let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache nseq =
-    let copyCachedTags (libraryTags: LibraryTags) =
-        { libraryTags with LastWriteTime = DateTimeOffset libraryTags.LastWriteTime.DateTime }
+let private prepareTagsToCache tagLibMap fileInfos : TagsToCache nseq =
+    let copyCachedTags (libTags: LibraryTags) =
+        { libTags with LastWriteTime = DateTimeOffset libTags.LastWriteTime.DateTime }
 
     let generateNewTags (fileInfo: FileInfo) : LibraryTags =
        let tagsFromFile (fileTags: FileTags) =
@@ -75,18 +74,18 @@ let private prepareTagsToWrite tagLibraryMap fileInfos : CategorizedTagsToCache 
        | Ok (Some tags) -> tagsFromFile tags
        | _ -> blankTags fileInfo
 
-    let prepareTagsToCache tagLibraryMap (audioFile: FileInfo) : CategorizedTagsToCache =
-        if tagLibraryMap |> Map.containsKey audioFile.FullName
+    let prepareTagsToCache tagLibMap (audioFile: FileInfo) : TagsToCache =
+        if tagLibMap |> Map.containsKey audioFile.FullName
         then
-            let libraryTags = tagLibraryMap |> Map.find audioFile.FullName
-            match compareWith libraryTags.LastWriteTime.DateTime audioFile.LastWriteTime with
+            let libTags = tagLibMap |> Map.find audioFile.FullName
+            match compareWith libTags.LastWriteTime.DateTime audioFile.LastWriteTime with
             | GT -> { Type = LibraryOutOfDate; Tags = generateNewTags audioFile }
-            | EQ -> { Type = UpToDate; Tags = copyCachedTags libraryTags }
+            | EQ -> { Type = UpToDate; Tags = copyCachedTags libTags }
             | LT -> { Type = FileOutOfDate; Tags = generateNewTags audioFile }
         else { Type = NewFile; Tags = generateNewTags audioFile }
 
     fileInfos
-    |> NSeq.map (prepareTagsToCache tagLibraryMap)
+    |> NSeq.map (prepareTagsToCache tagLibMap)
 
 let private countDeletedFiles tagLibMap categorizedTags =
     let filePaths = categorizedTags |> NSeq.map (fun t -> filePath t.Tags) |> set
@@ -118,7 +117,7 @@ let private reportResults (categorizedTags, DeletedFileCount deletedCount) : uni
 
 let generateJson tagMap fileInfos : Result<string, CommandError> =
     fileInfos
-    |> prepareTagsToWrite tagMap
+    |> prepareTagsToCache tagMap
     |> countDeletedFiles tagMap
     |- reportResults
     |> (fst >> map _.Tags)

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -32,7 +32,7 @@ type LibraryTags =
 
 type DuplicateTags = LibraryTags nlist nlist
 
-let blankTags (fileInfo: FileInfo) : LibraryTags =
+let emptyTags (fileInfo: FileInfo) : LibraryTags =
     { FileName = fileInfo.Name
       DirectoryName = fileInfo.DirectoryName
       Artists = [| String.Empty |]
@@ -57,8 +57,8 @@ let parseJsonToTags (Json json) : Result<LibraryTags list, string> =
 let parseJsonToNonEmptyTags json : Result<LibraryTags nlist, string> =
     parseJsonToTags json >>= List.toNonEmptyListResult "No tags were found to parse."
 
-let parseFileTags (f: FileInfo) : Result<FileTags option, string> =
-    try f.FullName |> FileTags.Create |> Option.ofObj |> Ok
+let parseFileTags (file: FileInfo) : Result<FileTags option, string> =
+    try file.FullName |> FileTags.Create |> Option.ofObj |> Ok
     with exn -> Error exn.Message
 
 let filePath tags : FilePath =

--- a/src/AudioTagTools.Shared/TagLibrary.fs
+++ b/src/AudioTagTools.Shared/TagLibrary.fs
@@ -57,6 +57,8 @@ let parseJsonToTags (Json json) : Result<LibraryTags list, string> =
 let parseJsonToNonEmptyTags json : Result<LibraryTags nlist, string> =
     parseJsonToTags json >>= List.toNonEmptyListResult "No tags were found to parse."
 
+/// Creates an instance representing a file's tags. The file itself might or might not already contain tags.
+/// If it does, the tags are wrapped in Some. Otherwise (i.e., if the tags are null), then None is given.
 let parseFileTags (file: FileInfo) : Result<FileTags option, string> =
     try file.FullName |> FileTags.Create |> Option.ofObj |> Ok
     with exn -> Error exn.Message


### PR DESCRIPTION
Adds the count of deleted items (i.e., a corresponding file no longer exists for existing library tags) to the caching process. (I've been meaning to do this for a while.)