### PR TITLE
Use correct JSON field names for paths

### DIFF
--- a/src/AudioTagTools.DuplicateFinder/IO.fs
+++ b/src/AudioTagTools.DuplicateFinder/IO.fs
@@ -30,8 +30,8 @@ let savePlaylist (settings: Settings) (maybeTags: DuplicateTags option) : Result
 
         let filePath =
             let originalPath = Path.Combine(fileTags.DirectoryName, fileTags.FileName)
-            match settings.Playlist.SearchPath,
-                  settings.Playlist.ReplacePath with
+            match settings.Playlist.PathSearchFor,
+                  settings.Playlist.PathReplaceWith with
             | s, _ when String.hasNoText s -> originalPath
             | s, r -> originalPath.Replace(s, r)
 

--- a/src/AudioTagTools.DuplicateFinder/Settings.fs
+++ b/src/AudioTagTools.DuplicateFinder/Settings.fs
@@ -9,8 +9,8 @@ let settingsSample = """
 {
     "playlist": {
         "saveDirectory": "path",
-        "searchPath": "path",
-        "replacePath": "path"
+        "pathSearchFor": "path",
+        "pathReplaceWith": "path"
     },
     "exclusionPatterns": [
         {


### PR DESCRIPTION
Fix path substring replacements not working during dupe-finding.